### PR TITLE
Fix extend frontend class

### DIFF
--- a/extend/quick-start.md
+++ b/extend/quick-start.md
@@ -465,7 +465,7 @@ namespace Acme\HelloWorld;
 use Flarum\Extend;
 
 return [
-    (new Extend\Assets('forum'))
+    (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
 ];
 ```


### PR DESCRIPTION
In `quick-start.md`, one example showed `Extend\Assets` instead of `Extend\Frontend`, and this PR fixes that.