### PR TITLE
Update quick-start.md

### DIFF
--- a/extend/quick-start.md
+++ b/extend/quick-start.md
@@ -446,6 +446,8 @@ To figure out your initializer name use this table:
 | vendor/flarum-package     | vendor-package             |
 | vendor/package            | vendor-package             |
 
+> When using an `extend.php` inside the Flarum root directory, the initializer has to be named `site-custom`.
+
 OK, time to fire up the transpiler. Run the following commands in the `js/forum` directory:
 
 ```bash


### PR DESCRIPTION
Take into consideration the `site-custom` initializer name when using extend.php from the root path. This is caused by not having an extension when including the JS, see:

https://github.com/flarum/core/blob/c446c5cc6174e5fde0d01495d80af126eb79804e/src/Extend/Frontend.php#L129-L132