### PR TITLE
Lighttpd access denial block

### DIFF
--- a/user/installation.md
+++ b/user/installation.md
@@ -110,6 +110,10 @@ Add the following lines to your server's configuration block:
     url.rewrite-if-not-file = (
         "/.*"      => "/index.php"
     )
+    
+    $HTTP["url"] =~ "^/(composer\.(json|lock)|config\.php|flarum|storage|vendor)" {
+        url.access-deny = ("")
+    }
 ```
 
 ## Importing Data


### PR DESCRIPTION
This PR adds a configuration block to the Lighttpd section inside the installation page that denies access to sensitive files (the same ones that the Nginx section shows).