### PR TITLE
Update Installation Docs

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ Beta is all about fixing these issues and improving Flarum. **Please don't use F
 Before you install Flarum, it's important to check that your server meets the requirements. To run Flarum, you will need:
 
 * **Apache** (with mod_rewrite enabled) or **Nginx**
-* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer
+* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, and curl
 * **MySQL 5.6+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run Composer
 


### PR DESCRIPTION
This PR adds the `php-curl` extension as it is required in the install. Not sure if it is a Flarum dependency, or a dependency of something that Flarum depends on....