### PR TITLE
Added necessary dependencies

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,8 @@ Beta is all about fixing these issues and improving Flarum. **Please don't use F
 Before you install Flarum, it's important to check that your server meets the requirements. To run Flarum, you will need:
 
 * **Apache** (with mod_rewrite enabled) or **Nginx**
-* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, curl, zip
+* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, curl
+* * When installing through composer, you'll need the zip extension, too
 * **MySQL 5.6+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run Composer
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ Beta is all about fixing these issues and improving Flarum. **Please don't use F
 Before you install Flarum, it's important to check that your server meets the requirements. To run Flarum, you will need:
 
 * **Apache** (with mod_rewrite enabled) or **Nginx**
-* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer
+* **PHP 7.1+** with the following extensions: dom, gd, json, mbstring, openssl, pdo_mysql, tokenizer, curl, zip
 * **MySQL 5.6+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run Composer
 


### PR DESCRIPTION
Zip is required by composer to download dependencies from dist, instead it shows a warning for each package and fetches each one from source. This isn't a dependency by Flarum itself, but when setting up a fresh machine it may be helpful to have it installed.

Curl is required by Flarum or their dependencies. Not quite sure who exactly depends on it, but `composer check-platform-reqs` tells me it's definitely a requirement:
```
padrio@board:/var/www/******.org/htdocs$ composer check-platform-reqs
ext-curl      7.2.16      success
ext-dom       20031129    success
ext-fileinfo  1.0.5       success
ext-filter    7.2.16      success
ext-json      1.6.0       success
ext-mbstring  7.2.16      success
ext-pcre      7.2.16      success
ext-PDO       7.2.16      success
lib-pcre      8.42        success
php           7.2.16      success
``` 