### PR TITLE
Update API reference link to new domain

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -10,7 +10,7 @@ module.exports = {
     nav: [
       { text: 'Guide', link: '/' },
       { text: 'Extend', link: '/extend/' },
-      { text: 'API Reference', link: 'https://api.flarum.redevs.org/' },
+      { text: 'API Reference', link: 'https://api.flarum.dev/' },
       {
         text: 'Flarum',
         items: [


### PR DESCRIPTION
Uses https://api.flarum.dev now, thanks @clarkwinkelmann