### PR TITLE
Remove dead link to namespace update script

### DIFF
--- a/docs/extend/update-b8.md
+++ b/docs/extend/update-b8.md
@@ -10,8 +10,6 @@ This guide is not comprehensive. You may encounter some changes we haven't docum
 
 Beta 8 comes with large changes to the overall structure of the PHP backend. You will need to look through [this list](https://discuss.flarum.org/d/6572-help-us-namespace-changes) of namespace changes and make changes to your extension accordingly.
 
-[This script](https://gist.github.com/tobscure/55e7c05c95404e5efab3a9e43799d375) can help you to automate most of the namespace changes. Of course, you should still test your extension after running the script as it may miss something.
-
 ## Database Naming
 
 Many database columns and JSON:API attributes have been renamed to conform to a [convention](/contributing.md#database). You will need to update any instances where your extension interacts with core data. You can see the changes in [#1344](https://github.com/flarum/core/pull/1344/files).


### PR DESCRIPTION
Unless the script is now hosted elsewhere (@tobyzerner ?) I suggest we remove the dead link.