### PR TITLE
Reinstate Free Flarum reference to install doc

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,6 +6,10 @@ Flarum is **beta software**. That means it still has some incomplete features an
 Beta is all about fixing these issues and improving Flarum. **Please don't use Flarum in production unless you know what you're doing**. We can’t support you if things go awry. Upgrading to subsequent versions will be possible, but might involve getting your hands dirty. 
 :::
 
+::: tip Quick test drive?
+If you just want to see if Flarum is suitable for you, you can set up a forum in seconds at [Free Flarum](https://www.freeflarum.com) (not affiliated with flarum.org).
+:::
+
 ## Server Requirements
 
 Before you install Flarum, it's important to check that your server meets the requirements. To run Flarum, you will need:


### PR DESCRIPTION
In the previous docs at flarum.github.io Toby had added a Free Flarum reference ([see here](https://github.com/flarum/flarum.github.io/commit/f27871c4ab835b7dec92a40198907c1d0d3864d1)) but it got lost in the docs migration. It would be nice to have it back, as to reduce the entry barrier for new Flarum users. See for example [this comment](https://discuss.flarum.org/d/7585-free-flarum-hosting-on-an-expert-platform-by-freeflarum-com/669):

![image](https://user-images.githubusercontent.com/1145479/62614128-1800df80-b90b-11e9-8455-b642ceebad12.png)

