### PR TITLE
Add Debian/Ubuntu PHP extensions to install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,7 @@ Before you install Flarum, it's important to check that your server meets the re
 
 * **Apache** (with mod\_rewrite enabled) or **Nginx**
 * **PHP 7.1+** with the following extensions: curl, dom, gd, json, mbstring, openssl, pdo\_mysql, tokenizer, zip
+  * Ubuntu/Debian: `sudo apt install php-curl php-xml php-gd php-json php-mbstring php-mysql php-zip`
 * **MySQL 5.6+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run Composer
 


### PR DESCRIPTION
I counted quite a few questions about missing PHP packages on the forum and chat channels. 
Plus, it is non-intuitive that you need the `php-xml` package to resolve a `php-dom` error from Composer. I left out php-openssl (only required on Windows) and php-tokenizer (not needed at all AFAICT). 