### PR TITLE
Fix Component import not working

### DIFF
--- a/docs/extend/frontend.md
+++ b/docs/extend/frontend.md
@@ -173,7 +173,7 @@ You should familiarize yourself with [Mithril's component API](https://mithril.j
 With these differences in mind, a basic component might look like this:
 
 ```jsx
-import { Component } from '@flarum/core/forum';
+import Component from 'flarum/Component';
 
 class Counter extends Component {
   init() {


### PR DESCRIPTION
Not sure why we mix `@flarum/core/forum` and `flarum/`, but only the latter worked for someone on Discord, so we should probably change it anyway.