### PR TITLE
Extensions: Tweak recommended version constraints

### DIFF
--- a/docs/extend/start.md
+++ b/docs/extend/start.md
@@ -89,7 +89,7 @@ We need to tell Composer a bit about our package, and we can do this by creating
     "description": "Say hello to the world!",
     "type": "flarum-extension",
     "require": {
-        "flarum/core": "0.1.0-beta.8"
+        "flarum/core": ">=0.1.0-beta.10 <0.1.0-beta.12"
     },
     "autoload": {
         "psr-4": {"Acme\\HelloWorld\\": "src/"}
@@ -117,7 +117,18 @@ We need to tell Composer a bit about our package, and we can do this by creating
 
 * **require** contains a list of your extension's own dependencies.
   * You'll want to specify the version of Flarum that your extension is compatible with here.
-  * Since Flarum is still in beta, do **not** specify a version range or prefix for the Flarum version, otherwise your extension may become installable on future incompatible beta versions.
+  * This is also the place to list other Composer libraries your code needs to work.
+
+  ::: warning Carefully choose the Flarum version
+  While Flarum is still in beta, we recommend that you declare compatibility both with the current and the upcoming beta version of Flarum:
+
+      "flarum/core": ">=0.1.0-beta.10 <0.1.0-beta.12"
+
+  This gives you time to update your extension for new features or changes in Flarum's core, without preventing users from upgrading to the latest Flarum release because your extension is not compatible.
+
+  To make this possible, we try to deprecate features for one beta cycle, before removing them for the next one, until we reach stable.
+  This gives you two months time to update.
+  :::
 
 * **autoload** tells Composer where to find your extension's classes. The namespace in here should reflect your extensions' vendor and package name in CamelCase.
 


### PR DESCRIPTION
Here's my proposal for reducing the compatibility problems with extensions, as a follow-up to the discussion in #49.

The idea: let extensions declare they're compatible with the current and upcoming versions of Flarum.

Benefits:
- Extensions following this recommendation can no longer prevent upgrades to the next version of Flarum.
- Extension authors have more time to make extensions compatible with new APIs and features in core.

Drawbacks:
- In theory, it is possible to install extensions that aren't compatible with your version of Flarum.

The proposed deprecation cycle of two months is meant to reduce the chance of that drawback becoming a problem, and give extension authors time to update their extensions without a rush after a new release has appeared. So we would have to be careful not to introduce any breaking changes whenever possible, unless we have offered (and advertised!) the alternative API for at least one beta release cycle.

---

NB: In hindsight, our versioning scheme doesn't work so well anymore. One of the reasons why our primary goal is to make the final breaking changes to our extension API so that we can finally declare 0.1 is done. Until that is the case, we have to adapt as best as we can.

---

**Things to review:**

- Wording okay?
- Is the explanation understandable? Is it too long?