### PR TITLE
Update Symfony links to point to version 3.3

### DIFF
--- a/docs/extend/i18n.md
+++ b/docs/extend/i18n.md
@@ -1,6 +1,6 @@
 # Internationalization
 
-Flarum features a powerful translation system (based on [Symfony's translator](https://symfony.com/doc/current/book/translation.html)) that allows the interface to display information in virtually any language. You should consider taking advantage of Flarum's translator as you develop your extension, even if you have no intention of using it in more than a single language.
+Flarum features a powerful translation system (based on [Symfony's translator](https://symfony.com/doc/3.4/translation.html)) that allows the interface to display information in virtually any language. You should consider taking advantage of Flarum's translator as you develop your extension, even if you have no intention of using it in more than a single language.
 
 For one thing, this system will allow you to change the information displayed by your extension without editing the actual code. It will also give you the tools needed to efficiently deal with phenomena such as pluralization and agreement for gender. And you never know: it may come in handy later if you decide you want to add more languages and make your extension available to users around the world!
 
@@ -189,7 +189,7 @@ When the `app.translator.transChoice()` method is called, the translator scans t
 choose_primary_placeholder: "Choose a primary tag|Choose {count} primary tags"
 ```
 
-Of course English has only two variants: singular or plural. You'll need to provide additional variants when creating translations for a language that has more than one plural form. If you need detailed information about the number of variants required for a language &mdash; or the order in which they should be listed &mdash; you can refer directly to the [pluralization rules](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/Translation/PluralizationRules.php) that Flarum uses to map the variable to plural forms.
+Of course English has only two variants: singular or plural. You'll need to provide additional variants when creating translations for a language that has more than one plural form. If you need detailed information about the number of variants required for a language &mdash; or the order in which they should be listed &mdash; you can refer directly to the [pluralization rules](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Translation/PluralizationRules.php) that Flarum uses to map the variable to plural forms.
 
 ### Dealing with Gender
 
@@ -208,7 +208,7 @@ $translator = app(Translator::class); // you'll need to import the class with 'u
 ```  
 
 Then, the API is similar to the JavaScript Translator class. You can use `$translator->trans` like you'd use `app.translator.trans` in JavaScript.
-You can learn more about the Translator's methods in [Symfony's `Translator` documentation](https://api.symfony.com/3.1/Symfony/Component/Translation/Translator.html), which Flarum's `Translator` extends.
+You can learn more about the Translator's methods in [Symfony's `Translator` documentation](https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Translation/Translator.php), which Flarum's `Translator` extends.
 
 ## Registering Locales
 

--- a/docs/extend/i18n.md
+++ b/docs/extend/i18n.md
@@ -1,6 +1,6 @@
 # Internationalization
 
-Flarum features a powerful translation system (based on [Symfony's translator](https://symfony.com/doc/3.4/translation.html)) that allows the interface to display information in virtually any language. You should consider taking advantage of Flarum's translator as you develop your extension, even if you have no intention of using it in more than a single language.
+Flarum features a powerful translation system (based on [Symfony's translator](https://symfony.com/doc/3.3/translation.html)) that allows the interface to display information in virtually any language. You should consider taking advantage of Flarum's translator as you develop your extension, even if you have no intention of using it in more than a single language.
 
 For one thing, this system will allow you to change the information displayed by your extension without editing the actual code. It will also give you the tools needed to efficiently deal with phenomena such as pluralization and agreement for gender. And you never know: it may come in handy later if you decide you want to add more languages and make your extension available to users around the world!
 


### PR DESCRIPTION
The PluralizationRules link was broken because it no longer exists in the latest Symfony. The other links pointed to outdated or too recent documentation.