### PR TITLE
feat: add DocSearch as recommended by vuepress

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -3,6 +3,10 @@ module.exports = {
   base: '/docs/',
 
   themeConfig: {
+     algolia: {
+      apiKey: '8f760cdb850b1e696b72329eed96b01b',
+      indexName: 'flarum'
+    },
     lastUpdated: 'Last Updated',
     docsRepo: 'flarum/docs',
     docsDir: 'docs',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Vuepress](https://vuepress.vuejs.org/theme/default-theme-config.html#algolia-search). We thought it is a shame you can not also used this search that you can [find on vuejs for example](https://vuejs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.