### PR TITLE
Change 'third party' to 'community'

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -7,7 +7,7 @@ Beta is all about fixing these issues and improving Flarum. **Please don't use F
 :::
 
 ::: tip Quick test drive?
-Feel free to give Flarum a spin on one of our [demonstration forums](https://discuss.flarum.org/d/21101). Or set up your own forum in seconds at [Free Flarum](https://www.freeflarum.com), a free third party service not affiliated with the Flarum team.
+Feel free to give Flarum a spin on one of our [demonstration forums](https://discuss.flarum.org/d/21101). Or set up your own forum in seconds at [Free Flarum](https://www.freeflarum.com), a free community service not affiliated with the Flarum team.
 :::
 
 ## Server Requirements

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -23,8 +23,8 @@ If you decide you don’t need to support a certain language, after all, you can
 
 Disabling a language can be useful if you’re running a monolingual site and don’t want the language selector to appear in the site header. The language selector is hidden when only one language is enabled.
 
-## Third-Party Extensions
+## Community Extensions
 
-While language packs downloaded from the Flarum Community site will generally include translations for all the extensions that come bundled with Flarum, they _will not_ as a rule cover any third-party extensions you may have installed. It is up to developers to provide and maintain translations for their extensions.
+While language packs downloaded from the Flarum Community site will generally include translations for all the extensions that come bundled with Flarum, they _will not_ as a rule cover any community extensions you may have installed. It is up to developers to provide and maintain translations for their extensions.
 
-So before you install a third-party extension, you should check to make sure it includes translations for each language pack you have installed. If you find that an extension doesn’t support a language you need, please contact the developer directly and arrange to have the necessary translations added.
+So before you install a community extension, you should check to make sure it includes translations for each language pack you have installed. If you find that an extension doesn’t support a language you need, please contact the developer directly and arrange to have the necessary translations added.


### PR DESCRIPTION
Following recent culture changes, it would be wise to bring this terminology in line with our approach to community projects (no longer calling them "third party").