### PR TITLE
Update caddy example config to address directive errors

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -68,16 +68,14 @@ Caddy requires a very simple configuration in order for Flarum to work properly.
 ```
 www.example.com {
     root /var/www/flarum/public
-    rewrite {
-        to {path} {path}/ /index.php
-    }
-    fastcgi / /var/run/php/php7.2-fpm.sock php
+    try_files {path} {path}/ /index.php
+    php_fastcgi / /var/run/php/php7.2-fpm.sock php
     header /assets {
         +Cache-Control "public, must-revalidate, proxy-revalidate"
         +Cache-Control "max-age=25000"
         Pragma "public" 
     }
-    gzip
+    encode gzip
 }
 ```
 ## Folder Ownership


### PR DESCRIPTION
I think the rewrite, cgi and gzip directives must be old, they have changed and the current example throws errors on Caddy 2.1

caddy.conf:3 - Error during parsing: Wrong argument count or unexpected line ending after 'rewrite'
caddy.conf:4: unrecognized directive: fastcgi
caddy.conf:10: unrecognized directive: gzip

This just updates to use the new directives.