### PR TITLE
Get started with Beta.14 upgrade guide

### DIFF
--- a/docs/.vuepress/config/locales/en/sidebar.js
+++ b/docs/.vuepress/config/locales/en/sidebar.js
@@ -14,6 +14,7 @@ module.exports = {
           'update-b10',
           'update-b12',
           'update-b13',
+          'update-b14',
         ]
       },
       {

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -702,16 +702,15 @@ Considering you have to do the changes anyway, why not do them now?
 
 ### Removals
 
-Warnings to users
-
-No more laravel helpers
-Symfony translator interface should be used, not Laravel's
-Do NOT use the old callback notation for configuring view namespaces. This will break all extensions that boot after your extension. The view extender must be used.
-
-*TODO*
-
-- The following events [deprecated in Beta 13](https://github.com/flarum/core/commit/4efdd2a4f2458c8703aae654f95c6958e3f7b60b) have been removed:
+- Do NOT use the old closure notation for configuring view namespaces. This will break all extensions that boot after your extension. The `View` extender MUST be used instead.
+- app()->url() will no longer work: [`Flarum\Http\UrlGenerator`](routes.md) should be injected and used instead. An instance of `Flarum\Http\UrlGenerator` is available in `blade.php` templates via `$url`.
+- As a part of the Laravel 6 upgrade, the [`array_` and `str_` helpers](https://laravel.com/docs/6.x/upgrade#helpers) have been removed.
+- The Laravel translator interface has been removed; the Symfony translator interface should be used instead: `Symfony\Component\Translation\TranslatorInterface`
+- The following events deprecated in Beta 13 [have been removed](https://github.com/flarum/core/commit/7d1ef9d89161363d1c8dea19cf8aebb30136e9e3#diff-238957b67e42d4e977398cd048c51c73):
   - `AbstractConfigureRoutes`
   - `ConfigureApiRoutes` - Use the `Routes` extender instead
   - `ConfigureForumRoutes` - Use the `Frontend` or `Routes` extenders instead
   - `ConfigureLocales` - Use the `LanguagePack` extender instead
+  - `ConfigureModelDates` - Use the `Model` extender instead
+  - `ConfigureModelDefaultAttributes` - Use the `Model` extender instead
+  - `GetModelRelationship` - Use the `Model` extender instead

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -320,6 +320,44 @@ extending Flarum's `Component` helper class. The best workaround here is to just
 
 *TODO: States, and other BC breaks*
 
+#### affixSidebar
+
+The `affixSidebar` util has been removed. Instead, if you want to affix a sidebar, wrap the sidebar code in an `AffixedSidebar` component. For instance,
+
+```js
+class OldWay extends Component {
+  view() {
+    return <div>
+      <div className="container">
+        <div className="sideNavContainer">
+          <nav className="sideNav" config={affixSidebar}>
+            <p>Affixed Sidebar</p>
+          </nav>
+          <div className="sideNavOffset">Actual Page Content</div>
+        </div>
+      </div>
+    </div>;
+  }
+}
+
+class NewWay extends Component {
+  view() {
+    return <div>
+      <div className="container">
+        <div className="sideNavContainer">
+          <AffixedSidebar>
+            <nav className="sideNav">
+              <p>Affixed Sidebar</p>
+            </nav>
+          </AffixedSidebar>
+          <div className="sideNavOffset">Actual Page Content</div>
+        </div>
+      </div>
+    </div>;
+  }
+}
+```
+
 ### How to upgrade a component
 
 #### Required changes

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -23,8 +23,6 @@ If your extension does not change the UI, consider yourself lucky. :-)
 Most breaking changes required by beta 14 are prompted by changes in Mithril 2.
 [Mithril's upgrade guide](https://mithril.js.org/migration-v02x.html) is an extremely useful resource, and should be consulted for more detailed information. A few key changes are explained below:
 
-*TODO: Explain*
-
 #### props -> attrs
 
 Props passed into component are now referred to as `attrs`, and can be accessed via `this.attrs` where you would prior use `this.props`. This was done to be closer to Mithril's preferred terminology. We have provided a temporary backwards compatibility layer for `this.props`, but recommend using `this.attrs`.
@@ -134,7 +132,36 @@ Please see [the mithril documentation](https://mithril.js.org/vnodes.html#struct
 
 #### Routing API
 
-TODO
+Mithril 2 introduces a few changes in the routing API. Most of these are quite simple:
+
+- `m.route()` to get the current route has been replaced by `m.route.get()`
+- `m.route(NEW_ROUTE)` to set a new route has been replaced by `m.route.set(NEW_ROUTE)`
+- When registering new routes, a component class should be provided, not a component instance.
+
+For example:
+
+```js
+// Mithril 0.2
+app.routes.new_page = { path: '/new', component: NewPage.component() }
+
+// Mithril 2.0
+app.routes.new_page = { path: '/new', component: NewPage }
+```
+
+Additionally, the preferred way of defining an internal (doesn't refresh the page when clicked) link has been changed.
+
+```js
+// Mithril 0.2
+<a href="/path" config={m.route}>Link Content</a>
+
+// Mithril 2
+<m.route.Link href="/path">Link Content</m.route.Link>
+
+// Or, for convenience through a Flarum util:
+<a route="/path">Link Content</a>
+```
+
+For a full list of routing-related changes, please see [the mithril documentation](https://mithril.js.org/migration-v02x.html).
 
 #### Redraw API
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -23,9 +23,19 @@ If your extension does not change the UI, consider yourself lucky. :-)
 Most breaking changes required by beta 14 are prompted by changes in Mithril 2.
 [Mithril's upgrade guide](https://mithril.js.org/migration-v02x.html) is an extremely useful resource, and should be consulted for more detailed information. A few key changes are explained below:
 
-#### props -> attrs
+#### props -> attrs; initProps -> initAttrs
 
 Props passed into component are now referred to as `attrs`, and can be accessed via `this.attrs` where you would prior use `this.props`. This was done to be closer to Mithril's preferred terminology. We have provided a temporary backwards compatibility layer for `this.props`, but recommend using `this.attrs`.
+
+Accordingly, `initProps` has been replaced with `initAttrs`, with a similar BC layer.
+
+#### m.prop -> m.stream
+
+Mithril streams, which were available via `m.prop` in Mithril 0.2, are now available via `m.stream`. `m.prop` will still work for now due to a temporary BC layer.
+
+#### m.withAttr -> withAttr
+
+The `m.withAttr` util has been removed from Mithril. We have provided `common/utils/withAttr`, which does the same thing. A temporary BC layer has been added for `m.withAttr`.
 
 #### Lifecycle Hooks
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -454,6 +454,10 @@ Methods for `hasDiscussions`, `isLoading`, `isSearchResults`, and `empty` have b
 
 TODO
 
+#### SearchState and GlobalSearchState
+
+TODO
+
 #### moment -> dayjs
 
 The `moment` library has been removed, and replaced by the `dayjs` library. The global `moment` can still be used for now, but is deprecated. `moment` and `dayjs` have very similar APIs, so very few changes will be needed. Please see the dayjs documentation [for more information](https://day.js.org/en/) on how to use it.

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -126,6 +126,22 @@ class NewMithrilComponent extends Component {
 }
 ```
 
+#### Children vs Text Nodes
+
+TODO
+
+#### Routing API
+
+TODO
+
+#### Redraw API
+
+TODO
+
+#### AJAX
+
+TODO
+
 #### Component instances should not be stored
 
 Due to optimizations in Mithril's redrawing algorithms, [component instances should not be stored](https://mithril.js.org/components.html#define-components-statically,-call-them-dynamically).
@@ -267,6 +283,46 @@ This replaces the old method of passing the alert instance itself to `dismiss`.
 
 The `show`, `dismiss`, and `clear` methods are still available through `app.alerts`, but `app.alerts` now points to an instance of `AlertManagerState`, not of the `AlertManager` component.
 Any modifications by extensions should accordingly be done to `AlertManagerState`.
+
+#### Composer
+
+TODO
+
+#### Widget and DashboardWidget
+
+Widget Removed (TODO)
+
+#### NotificationList
+
+TODO
+
+#### Checkbox
+
+Loading is now a prop
+
+#### Preference Saver
+
+Deprecated / removed. Will eventually replace, maybe not in time for beta 14 though.
+
+#### DiscussionListState
+
+TODO
+
+#### PageState
+
+TODO
+
+#### PostStream
+
+TODO
+
+#### moment -> dayjs
+
+TODO
+
+#### Fragment
+
+TODO: Explain what it is, when it should be used, and when it should NOT be used. (only with m.render()).
 
 #### Subtree Retainer
 
@@ -443,14 +499,27 @@ Considering you have to do the changes anyway, why not do them now?
 ### New Features
 
 *TODO*
+- We are now on Laravel 6
+- Optional params in url generator now work
+- View Extender
+- User Extender (prepareGroups)
+- Error handler middleware can now be manipulated by middleware extender
+- Display Name Extender
 
 ### Deprecations
 
 *TODO*
 
 - TODO: `url` as array in `config.php` - [PR](https://github.com/flarum/core/pull/2271#discussion_r475930358)
+- AssertPermissionTrait has been deprecated - [Issue](https://github.com/flarum/core/issues/1320)
 
 ### Removals
+
+Warnings to users
+
+No more laravel helpers
+Symfony translator interface should be used, not Laravel's
+Do NOT use the old callback notation for configuring view namespaces. This will break all extensions that boot after your extension. The view extender must be used.
 
 *TODO*
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -231,7 +231,8 @@ So whereas before, you might have done something like:
 
 ```js
 class ChildComponent extends Component {
-  init() {
+  oninit(vnode) {
+    super.oninit(vnode);
     this.counter = 0;
   }
 
@@ -240,7 +241,8 @@ class ChildComponent extends Component {
   }
 }
 class ParentComponent extends Component {
-  init() {
+  oninit(vnode) {
+    super.oninit(vnode);
     this.child = new ChildComponent();
   }
 
@@ -267,7 +269,8 @@ class ChildComponent extends Component {
 }
 
 class ParentComponent extends Component {
-  init() {
+  oninit(vnode) {
+    super.oninit(vnode);
     this.counter = 0;
   }
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -443,7 +443,7 @@ TODO
 
 #### moment -> dayjs
 
-TODO
+The `moment` library has been removed, and replaced by the `dayjs` library. The global `moment` can still be used for now, but is deprecated. `moment` and `dayjs` have very similar APIs, so very few changes will be needed. Please see the dayjs documentation [for more information](https://day.js.org/en/) on how to use it.
 
 #### Fragment
 
@@ -617,6 +617,7 @@ Considering you have to do the changes anyway, why not do them now?
 - static `initProps()` -> static `initAttrs()`
 - `m.prop` -> `m.stream`
 - `m.withAttr` -> `withAttr` with import
+- `moment` -> `dayjs`
 
 
 ## Backend (PHP)

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -392,7 +392,9 @@ The redundant `admin/components/Widget` component has been removed. `admin/compo
 
 #### NotificationList
 
-TODO
+For `forum/components/NotificationList`, the `clear`, `load`, `loadMore`, `parseResults`, and `markAllAsRead` methods have been moved to `forum/states/NotificationListState`.
+
+Methods for `isLoading` and `hasMoreResults` have been added to `forum/states/NotificationListState`.
 
 #### Checkbox
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -674,14 +674,12 @@ When you have taken care of the changes above, you should be good to go.
 For the following changes, we have bought you time until the stable release.
 Considering you have to do the changes anyway, why not do them now?
 
-*TODO*
 
 - `this.props` -> `this.attrs`
 - static `initProps()` -> static `initAttrs()`
 - `m.prop` -> `m.stream`
 - `m.withAttr` -> `withAttr` with import
 - `moment` -> `dayjs`
-
 
 ## Backend (PHP)
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -360,7 +360,7 @@ TODO
 
 #### Widget and DashboardWidget
 
-Widget Removed (TODO)
+The redundant `flarum/admin/components/Widget` component has been removed. `flarum/admin/components/DashboardWidget` should be used instead.
 
 #### NotificationList
 
@@ -368,11 +368,40 @@ TODO
 
 #### Checkbox
 
-Loading is now a prop
+Loading state in the `flarum/common/components/Checkbox` component is no longer managed through `this.loading`; it is now passed in as a prop (`this.attrs.loading`).
 
 #### Preference Saver
 
-Deprecated / removed. Will eventually replace, maybe not in time for beta 14 though.
+The `preferenceSaver` method of `flarum/forum/components/SettingsPage` has been removed without replacement. This is done to avoid saving component instances. Instead, preferences should be directly saved. For instance:
+
+```js
+// Old way
+Switch.component({
+  children: app.translator.trans('core.forum.settings.privacy_disclose_online_label'),
+  state: this.user.preferences().discloseOnline,
+  onchange: (value, component) => {
+    this.user.pushAttributes({ lastSeenAt: null });
+    this.preferenceSaver('discloseOnline')(value, component);
+  },
+})
+
+// Without preferenceSaver
+Switch.component({
+  children: app.translator.trans('core.forum.settings.privacy_disclose_online_label'),
+  state: this.user.preferences().discloseOnline,
+  onchange: (value) => {
+    this.discloseOnlineLoading = true;
+
+    this.user.savePreferences({ discloseOnline: value }).then(() => {
+      this.discloseOnlineLoading = false;
+      m.redraw();
+    });
+  },
+  loading: this.discloseOnlineLoading,
+})
+```
+
+A replacement will eventually be introduced.
 
 #### DiscussionListState
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -242,7 +242,7 @@ Button.component({
 });
 ```
 
-This will no longer work, and will actually result in errors. Instead, the 3rd argument of the component method should be used:
+This will no longer work, and will actually result in errors. Instead, the 2nd argument of the `component` method should be used:
 
 ```js
 Button.component({
@@ -255,6 +255,11 @@ Children can still be passed in through JSX:
 ```js
 <Button className='Button Button--primary'>Button Text</Button>
 ```
+
+#### Tag attr
+
+Because mithril uses 'tag' to indicate the actual html tag (or component class) used for a vnode, you can no longer pass `tag` as an attr to components
+extending Flarum's `Component` helper class. The best workaround here is to just use another name for this attr.
 
 *TODO: States, and other BC breaks*
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -165,11 +165,50 @@ For a full list of routing-related changes, please see [the mithril documentatio
 
 #### Redraw API
 
-TODO
+Mithril 2 introduces a few changes in the redraw API. Most of these are quite simple:
+
+- Instead of `m.redraw(true)` for synchronous redraws, use `m.redraw.sync()`
+- Instead of `m.lazyRedraw()`, use `m.redraw()`
+
+Remember that Mithril automatically triggers a redraw after DOM event handlers. The API for preventing a redraw has also changed:
+
+```js
+// Mithril 0.2
+<button onclick={() => {
+  console.log("Hello world");
+  m.redraw.strategy('none');
+}}>
+  Click Me!
+</button>
+
+// Mithril 0.2
+<button onclick={e => {
+  console.log("Hello world");
+  e.redraw = false;
+}}>
+  Click Me!
+</button>
+```
 
 #### AJAX
 
 TODO
+
+#### Promises
+
+`m.deferred` has been removed, native promises should be used instead. For instance:
+
+```js
+// Mithril 0.2
+const deferred = m.deferred();
+
+app.store.find('posts').then(result => deferred.resolve(result));
+
+return deferred.promise;
+
+// Mithril 2
+return app.store.find('posts');
+```
 
 #### Component instances should not be stored
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -128,7 +128,9 @@ class NewMithrilComponent extends Component {
 
 #### Children vs Text Nodes
 
-TODO
+In Mithril 0.2, every child of a vnode is another vnode, stored in `vnode.children`. For Mithril 2, as a performance optimization, vnodes with a single text child now store that text directly in `vnode.text`. For developers, that means that `vnode.children` might not always contain the results needed. Luckily, text being stored in `vnode.text` vs `vnode.children` will be the same each time for a given component, but developers should be aware that at times, they might need to use `vnode.text` and not `vnode.children`.
+
+Please see [the mithril documentation](https://mithril.js.org/vnodes.html#structure) for more information on vnode structure.
 
 #### Routing API
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -450,6 +450,13 @@ Methods for `hasDiscussions`, `isLoading`, `isSearchResults`, and `empty` have b
 - Instead of `app.current instanceof X`, use `app.current.matches(X)`
 - Instead of `app.current.PROPERTY`, use `app.current.get('PROPERTY')`. Please note that all properties must be exposed EXPLICITLY via `app.current.set('PROPERTY', VALUE)`.
 
+#### Pages and `oninit`
+
+Due to Mithril routing changes, `oninit` is NOT called again if a route is changed AND the same component handles the new route. For instance, if you go directly from one discussion's page to another, `oninit` will not be called. See https://mithril.js.org/route.html#key-parameter. In core, we have identified 2 strategies that, when used together, replicate previous behavior.
+
+- If the route is programatically changed, and we always want to recreate the page component, we can use the `common/utils/setRouteWithForcedRefresh` util. Under the surface, this uses a unique key as per the above Mithril documentation.
+- When creating a page, we can store the current path under `this.prevRoute`. THen, in `onbeforeupdate`, if `m.route.get()` is different from `this.prevRoute`, we can load in new data for this page and re-render. For an example, see `DiscussionPage` and `UserPage`
+
 #### PostStream
 
 Logic from `forum/components/PostStreamScrubber`'s `update` method has been moved to `forum/components/PostStream`'s `updateScrubber` method.

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -1,0 +1,98 @@
+# Updating For Beta 14
+
+This release brings a large chunk of breaking changes - hopefully the last chunk of this size.
+In order to prepare the codebase for the upcoming stable release, we decided it was time to modernize / upgrade / exchange some of the underlying JavaScript libraries that are used in the frontend.
+Due to the nature and size of these upgrades, we have to pass on some of the breaking changes to you, our extension developers.
+
+On the bright side, this overdue upgrade brings us closer to the conventions of best practices of [Mithril.js](https://mithril.js.org/), the mini-framework used for Flarum's UI.
+Mithril's 2.0 release sports a more consistent component interface, which should be a solid foundation for years to come.
+Where possible, we replicated old APIs, to ease the upgrade and give you time to do the full transition.
+Quite a few breaking changes remain, though - read more below.
+
+::: tip
+If you need help with the upgrade, our friendly community will gladly help you out either [on the forum](https://discuss.flarum.org/t/extensibility) or [in chat](https://flarum.org/chat/).
+:::
+
+To ease the process, we've clearly separated the changes to the frontend (JS) from those in the backend (PHP) below.
+If your extension does not change the UI, consider yourself lucky. :-)
+
+## Frontend (JavaScript)
+
+### Changes in Core
+
+*TODO: States, and other BC breaks*
+
+### Mithril 2.0: Concepts
+
+*TODO: Explain*
+
+- props -> attrs
+- vnodes
+- Component instances should not be stored
+
+### How to upgrade a component
+
+#### Required changes
+
+*TODO*
+
+- `view()` -> `view(vnode)`
+- Lifecycle
+  - `init()` -> `oninit(vnode)`
+  - `config()` -> Lifecycle hooks `oncreate(vnode)` / `onupdate(vnode)`
+  - `context.onunload()` -> `onremove()`
+  - `SubtreeRetainer` -> `onbeforeupdate()`
+- if present, `attrs()` method needs to be renamed -> convention `elementAttrs()`
+- building component with `MyComponent.component()` -> `children` is now second parameter instead of a named prop/attr (first argument) -> JSX preferred
+- Routing
+  - `m.route()` -> `m.route.get()`
+  - `m.route(name)` -> `m.route.set(name)`
+  - register routes with page class, not instance
+    - special case when passing props
+  - `<a href={url} config={m.route}>` -> `<a route={url}>`
+- AJAX
+  - `m.request({...})` -> `data:` key split up into `body:` and `params:`
+  - `m.deferred` -> native `Promise`
+- Redrawing
+  - `m.redraw(true)` -> `m.redraw.sync()`
+  - `m.redraw.strategy('none')` -> `e.redraw = false` in event handler
+  - `m.lazyRedraw()` -> `m.redraw()`
+
+#### Optional changes
+
+For the following changes, we currently provide a backwards-compatibility layer.
+This will be removed in time for the stable release.
+The idea is to let you release a new version that's compatible with Beta 14 to your users as quickly as possible.
+When you have taken care of the changes above, you should be good to go.
+For the following changes, we have bought you time until the stable release.
+Considering you have to do the changes anyway, why not do them now?
+
+*TODO*
+
+- `this.props` -> `this.attrs`
+- static `initProps()` -> static `initAttrs()`
+- `m.prop` -> `m.stream`
+- `m.withAttr` -> `withAttr` with import
+
+
+## Backend (PHP)
+
+### New Features
+
+*TODO*
+
+### Deprecations
+
+*TODO*
+
+- TODO: `url` as array in `config.php` - [PR](https://github.com/flarum/core/pull/2271#discussion_r475930358)
+
+### Removals
+
+*TODO*
+
+- The following events [deprecated in Beta 13](https://github.com/flarum/core/commit/4efdd2a4f2458c8703aae654f95c6958e3f7b60b) have been removed:
+  - `AbstractConfigureRoutes`
+  - `ConfigureApiRoutes` - Use the `Routes` extender instead
+  - `ConfigureForumRoutes` - Use the `Frontend` or `Routes` extenders instead
+  - `ConfigureLocales` - Use the `LanguagePack` extender instead

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -396,6 +396,8 @@ For `forum/components/NotificationList`, the `clear`, `load`, `loadMore`, `parse
 
 Methods for `isLoading` and `hasMoreResults` have been added to `forum/states/NotificationListState`.
 
+`app.cache.notifications` is no longer available; `app.notifications` (which points to an instance of `NotificationListState`) should be used instead.
+
 #### Checkbox
 
 Loading state in the `common/components/Checkbox` component is no longer managed through `this.loading`; it is now passed in as a prop (`this.attrs.loading`).
@@ -435,7 +437,11 @@ A replacement will eventually be introduced.
 
 #### DiscussionListState
 
-TODO
+For `forum/components/DiscussionList`, the `requestParams`, `sortMap`, `refresh`, `loadResults`, `loadMore`, `parseResults`, `removeDiscussion`, and `addDiscussion` methods have been moved to `forum/states/DiscussionListState`.
+
+Methods for `hasDiscussions`, `isLoading`, `isSearchResults`, and `empty` have been added to `forum/states/DiscussionListState`.
+
+`app.cache.discussions` is no longer available; `app.discussions` (which points to an instance of `DiscussionListState`) should be used instead.
 
 #### PageState
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -248,6 +248,26 @@ app.modal.show(LoginModal, {identification: 'prefilledUsername'});
 The `show` and `close` methods are still available through `app.modal`, but `app.modal` now points to an instance of `ModalManagerState`, not of the `ModalManager` component.
 Any modifications by extensions should accordingly be done to `ModalManagerState`.
 
+#### Alerts
+
+Previously, alerts could be opened by providing an `Alert` component instance:
+
+```js
+app.alerts.show(new Alert(type: 'success', children: 'Hello, this is a success alert!'));
+```
+
+Since we don't store component instances anymore, we pass in children, attrs, and (optionally) a component class separately.
+
+```js
+app.alerts.show('Hello, this is a success alert!', {type: 'success'}, Alert); // 3rd argument is optional, defaults to Alert.
+```
+
+Additionally, the `show` method now returns a unique key, which can then be passed into the `dismiss` method to dismiss that particular alert.
+This replaces the old method of passing the alert instance itself to `dismiss`.
+
+The `show`, `dismiss`, and `clear` methods are still available through `app.alerts`, but `app.alerts` now points to an instance of `AlertManagerState`, not of the `AlertManager` component.
+Any modifications by extensions should accordingly be done to `AlertManagerState`.
+
 #### Subtree Retainer
 
 `SubtreeRetainer` is a util class that makes it easier to avoid unnecessary redraws by keeping track of some pieces of data.
@@ -334,8 +354,6 @@ Children can still be passed in through JSX:
 
 Because mithril uses 'tag' to indicate the actual html tag (or component class) used for a vnode, you can no longer pass `tag` as an attr to components
 extending Flarum's `Component` helper class. The best workaround here is to just use another name for this attr.
-
-*TODO: States, and other BC breaks*
 
 #### affixSidebar
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -488,10 +488,6 @@ To use a custom search, you'll want to:
 
 The `moment` library has been removed, and replaced by the `dayjs` library. The global `moment` can still be used for now, but is deprecated. `moment` and `dayjs` have very similar APIs, so very few changes will be needed. Please see the dayjs documentation [for more information](https://day.js.org/en/) on how to use it.
 
-#### Fragment
-
-TODO: Explain what it is, when it should be used, and when it should NOT be used. (only with m.render()).
-
 #### Subtree Retainer
 
 `SubtreeRetainer` is a util class that makes it easier to avoid unnecessary redraws by keeping track of some pieces of data.
@@ -616,6 +612,20 @@ class NewWay extends Component {
   }
 }
 ```
+
+#### Fragment
+
+**Warning: For Advanced Use Only**
+
+In some rare cases, we want to have extremely fine grained control over the rendering and display of some significant chunks of the DOM. These are attached with `m.render`, and do not experience automated redraws. Current use cases in core and bundled extensions are:
+
+- The "Reply" button that shows up when selecting text in a post
+- The mentions autocomplete menu that shows up when typing
+- The emoji autocomplete menu that shows up when typing
+
+For this purpose, we provide a helper class (`common/Fragment`), of which you can create an instance, call methods, and render via `m.render(DOM_ROOT, fragmentInstance.render())`. The main benefit of using the helper class is that it allows you to use lifecycle methods, and to access the underlying DOM via `this.$()`, like you would be able to do with a component.
+
+This should only be used when absolutely necessary. If you are unsure, you probably don't need it. If the goal is to not store component instances, the "state pattern" as described above is preferable.
 
 ### How to upgrade a component
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -456,7 +456,11 @@ TODO
 
 #### SearchState and GlobalSearchState
 
-TODO
+Logic from `forum/components/PostStreamScrubber`'s `update` method has been moved to `forum/components/PostStream`'s `updateScrubber` method.
+
+For `forum/components/PostStream`, the `update`, `goToFirst`, `goToLast`, `goToNumber`, `goToIndex`, `loadNearNumber`, `loadNearIndex`, `loadNext`, `loadPrevious`, `loadPage`, `loadRange`, `show`, `posts`, `reset`, `count`, and `sanitizeIndex` methods have been moved to `forum/states/PostStreamState`.
+
+Methods for `disabled` and `viewingEnd` have been added to `forum/states/PostStreamState`.
 
 #### moment -> dayjs
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -356,11 +356,37 @@ Any modifications by extensions should accordingly be done to `AlertManagerState
 
 #### Composer
 
-TODO
+Since we don't store a component instances anymore, a number of util methods from `Composer`, `ComposerBody` (and it's subclasses), and `TextEditor` have been moved onto `ComposerState`.
+
+For `forum/components/Composer`, `isFullScreen`, `load`, `clear`, `show`, `hide`, `close`, `minimize`, `fullScreen`, and `exitFullScreen` have been moved to `forum/states/ComposerState`. They all remain accessible via `app.composer.METHOD`
+
+A `bodyMatches` method has been added to `forum/states/ComposerState`, letting you check whether a certain subclass of `ComposerBody` is currently open.
+
+Various input fields are now stored as [Mithril Streams](https://mithril.js.org/stream.html) in `app.composer.fields`. For instance, to get the current composer content, you could use `app.composer.fields.content()`. Previously, it was available on `app.composer.component.content()`. This is a convention that `ComposerBody` subclasses that add inputs should follow.
+
+`app.composer.component` is no longer available.
+
+- Instead of `app.composer.component instanceof X`, use `app.composer.bodyMatches(X)`.
+- Instead of `app.composer.component.props`, use `app.composer.body.attrs`.
+- Instead of `app.composer.component.editor`, use `app.composer.editor`.
+
+For `forum/components/TextEditor`, the `setValue`, `moveCursorTo`, `getSelectionRange`, `insertAtCursor`, `insertAt`, `insertBetween`, `replaceBeforeCursor`, `insertBetween` methods have been moved to `forum/components/SuperTextarea`.
+
+Similarly to Modals and Alerts, `app.composer.load` no longer accepts a component instance. Instead, pass in the body class and any attrs. For instance,
+
+```js
+// Mithril 0.2
+app.composer.load(new DiscussionComposer({user: app.session.user}));
+
+// Mithril 2
+app.composer.load(DiscussionComposer, {user: app.session.user})
+```
+
+Finally, functionality for confirming before unloading a page with an active composer has been moved into the `common/components/ConfirmDocumentUnload` component.
 
 #### Widget and DashboardWidget
 
-The redundant `flarum/admin/components/Widget` component has been removed. `flarum/admin/components/DashboardWidget` should be used instead.
+The redundant `admin/components/Widget` component has been removed. `admin/components/DashboardWidget` should be used instead.
 
 #### NotificationList
 
@@ -368,11 +394,11 @@ TODO
 
 #### Checkbox
 
-Loading state in the `flarum/common/components/Checkbox` component is no longer managed through `this.loading`; it is now passed in as a prop (`this.attrs.loading`).
+Loading state in the `common/components/Checkbox` component is no longer managed through `this.loading`; it is now passed in as a prop (`this.attrs.loading`).
 
 #### Preference Saver
 
-The `preferenceSaver` method of `flarum/forum/components/SettingsPage` has been removed without replacement. This is done to avoid saving component instances. Instead, preferences should be directly saved. For instance:
+The `preferenceSaver` method of `forum/components/SettingsPage` has been removed without replacement. This is done to avoid saving component instances. Instead, preferences should be directly saved. For instance:
 
 ```js
 // Old way

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -192,7 +192,9 @@ Remember that Mithril automatically triggers a redraw after DOM event handlers. 
 
 #### AJAX
 
-TODO
+The `data` parameter of `m.request({...})` has been split up into `body` and `params`.
+
+For examples and other AJAX changes, see [the mithril documentation](https://mithril.js.org/migration-v02x.html#mrequest).
 
 #### Promises
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -27,7 +27,7 @@ Most breaking changes required by beta 14 are prompted by changes in Mithril 2.
 
 #### props -> attrs
 
-Props passed into component are now referred to as `attrs`, and can be accessed via `this.attrs` where you would prior use `this.props`. This was done to be closer to Mithril's preferred terminology. We have provided a temporary backwards compatibility layer for `this.props`, but recommend using `this.attrs.
+Props passed into component are now referred to as `attrs`, and can be accessed via `this.attrs` where you would prior use `this.props`. This was done to be closer to Mithril's preferred terminology. We have provided a temporary backwards compatibility layer for `this.props`, but recommend using `this.attrs`.
 
 #### Lifecycle Hooks
 
@@ -231,6 +231,30 @@ This "state pattern" can be found throughout core. Some non-trivial examples are
 
 ### Changes in Core
 
+#### Children and .component
+
+Previously, an element could be created with child elements by passing those in as the `children` prop:
+
+```js
+Button.component({
+  className: 'Button Button--primary',
+  children: 'Button Text'
+});
+```
+
+This will no longer work, and will actually result in errors. Instead, the 3rd argument of the component method should be used:
+
+```js
+Button.component({
+  className: 'Button Button--primary'
+}, 'Button Text');
+```
+
+Children can still be passed in through JSX:
+
+```js
+<Button className='Button Button--primary'>Button Text</Button>
+```
 
 *TODO: States, and other BC breaks*
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -452,15 +452,15 @@ Methods for `hasDiscussions`, `isLoading`, `isSearchResults`, and `empty` have b
 
 #### PostStream
 
-TODO
-
-#### SearchState and GlobalSearchState
-
 Logic from `forum/components/PostStreamScrubber`'s `update` method has been moved to `forum/components/PostStream`'s `updateScrubber` method.
 
 For `forum/components/PostStream`, the `update`, `goToFirst`, `goToLast`, `goToNumber`, `goToIndex`, `loadNearNumber`, `loadNearIndex`, `loadNext`, `loadPrevious`, `loadPage`, `loadRange`, `show`, `posts`, `reset`, `count`, and `sanitizeIndex` methods have been moved to `forum/states/PostStreamState`.
 
 Methods for `disabled` and `viewingEnd` have been added to `forum/states/PostStreamState`.
+
+#### SearchState and GlobalSearchState
+
+TODO
 
 #### moment -> dayjs
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -231,6 +231,23 @@ This "state pattern" can be found throughout core. Some non-trivial examples are
 
 ### Changes in Core
 
+#### Modals
+
+Previously, modals could be opened by providing a `Modal` component instance:
+
+```js
+app.modal.show(new LoginModal(identification: 'prefilledUsername'));
+```
+
+Since we don't store component instances anymore, we pass in the component class and any attrs separately.
+
+```js
+app.modal.show(LoginModal, {identification: 'prefilledUsername'});
+```
+
+The `show` and `close` methods are still available through `app.modal`, but `app.modal` now points to an instance of `ModalManagerState`, not of the `ModalManager` component.
+Any modifications by extensions should accordingly be done to `ModalManagerState`.
+
 #### Subtree Retainer
 
 `SubtreeRetainer` is a util class that makes it easier to avoid unnecessary redraws by keeping track of some pieces of data.

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -181,7 +181,7 @@ Remember that Mithril automatically triggers a redraw after DOM event handlers. 
   Click Me!
 </button>
 
-// Mithril 0.2
+// Mithril 2
 <button onclick={e => {
   console.log("Hello world");
   e.redraw = false;

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -435,7 +435,10 @@ TODO
 
 #### PageState
 
-TODO
+`app.current` and `app.previous` no longer represent component instances, they are now instances of the `common/states/PageState` class. This means that:
+
+- Instead of `app.current instanceof X`, use `app.current.matches(X)`
+- Instead of `app.current.PROPERTY`, use `app.current.get('PROPERTY')`. Please note that all properties must be exposed EXPLICITLY via `app.current.set('PROPERTY', VALUE)`.
 
 #### PostStream
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -378,7 +378,7 @@ For `forum/components/Composer`, `isFullScreen`, `load`, `clear`, `show`, `hide`
 
 A `bodyMatches` method has been added to `forum/states/ComposerState`, letting you check whether a certain subclass of `ComposerBody` is currently open.
 
-Various input fields are now stored as [Mithril Streams](https://mithril.js.org/stream.html) in `app.composer.fields`. For instance, to get the current composer content, you could use `app.composer.fields.content()`. Previously, it was available on `app.composer.component.content()`. This is a convention that `ComposerBody` subclasses that add inputs should follow.
+Various input fields are now stored as [Mithril Streams](https://mithril.js.org/stream.html) in `app.composer.fields`. For instance, to get the current composer content, you could use `app.composer.fields.content()`. Previously, it was available on `app.composer.component.content()`. **This is a convention that `ComposerBody` subclasses that add inputs should follow.**
 
 `app.composer.component` is no longer available.
 
@@ -643,20 +643,19 @@ For this purpose, we provide a helper class (`common/Fragment`), of which you ca
 
 This should only be used when absolutely necessary. If you are unsure, you probably don't need it. If the goal is to not store component instances, the "state pattern" as described above is preferable.
 
-### How to upgrade a component
-
-#### Required changes recap
+### Required changes recap
 
 Each of these changes has been explained above, this is just a recap of major changes for your convenience.
 
-- `view()` -> `view(vnode)`
-- Lifecycle
-  - `init()` -> `oninit(vnode)`
-  - `config()` -> Lifecycle hooks `oncreate(vnode)` / `onupdate(vnode)`
-  - `context.onunload()` -> `onremove()`
-  - `SubtreeRetainer` -> `onbeforeupdate()`
-- if present, `attrs()` method needs to be renamed -> convention `elementAttrs()`
-- building component with `MyComponent.component()` -> `children` is now second parameter instead of a named prop/attr (first argument) -> JSX preferred
+- Component Methods:
+  - `view()` -> `view(vnode)`
+  - Lifecycle
+    - `init()` -> `oninit(vnode)`
+    - `config()` -> Lifecycle hooks `oncreate(vnode)` / `onupdate(vnode)`
+    - `context.onunload()` -> `onremove()`
+    - `SubtreeRetainer` -> `onbeforeupdate()`
+  - if present, `attrs()` method needs to be renamed -> convention `elementAttrs()`
+  - building component with `MyComponent.component()` -> `children` is now second parameter instead of a named prop/attr (first argument) -> JSX preferred
 - Routing
   - `m.route()` -> `m.route.get()`
   - `m.route(name)` -> `m.route.set(name)`
@@ -670,7 +669,6 @@ Each of these changes has been explained above, this is just a recap of major ch
   - `m.redraw(true)` -> `m.redraw.sync()`
   - `m.redraw.strategy('none')` -> `e.redraw = false` in event handler
   - `m.lazyRedraw()` -> `m.redraw()`
-- `m.withAttr` => `flarum/utils/withAttr`
 
 #### Deprecated changes
 
@@ -679,13 +677,12 @@ This will be removed in time for the stable release.
 The idea is to let you release a new version that's compatible with Beta 14 to your users as quickly as possible.
 When you have taken care of the changes above, you should be good to go.
 For the following changes, we have bought you time until the stable release.
-Considering you have to do the changes anyway, why not do them now?
-
+Considering you have to make changes anyway, why not do them now?
 
 - `this.props` -> `this.attrs`
 - static `initProps()` -> static `initAttrs()`
 - `m.prop` -> `flarum/utils/Stream`
-- `m.withAttr` -> `flarum/utils/withAttr` with import
+- `m.withAttr` -> `flarum/utils/withAttr`
 - `moment` -> `dayjs`
 
 ## Backend (PHP)
@@ -741,13 +738,21 @@ return [
 ]
 ```
 
+#### Application and Container
+
+Although Flarum uses multiple components of the Laravel framework, it is not a pure Laravel system. In beta 14, the `Flarum\Foundation\Application` class no longer implements `Illuminate\Contracts\Foundation\Application`, and no longer inherits `Illuminate\Container\Container`. Several things to note:
+
+- The `app` helper now points to an instance of `Illuminate\Container\Container`, not `Flarum\Foundation\Application`. You might need to resolve things through the container before using them: for instance, `app()->url()` will no longer work; you'll need to resolve or inject an instance of `Flarum\Foundation\Config` and use that.
+- Injected or resolved instances of `Flarum\Foundation\Application` can no longer resolve things through container methods. `Illuminate\Container\Container` should be used instead.
+- Not all public members of `Illuminate\Contracts\Foundation\Application` are available through `Flarum\Foundation\Application`. Please refer to our [API docs on `Flarum\Foundation\Application`](https://api.docs.flarum.org/php/master/flarum/foundation/application) for more information.
+
 #### Other Changes
 
 - We are now using Laravel 6. Please see [Laravel's upgrade guide](https://laravel.com/docs/6.x/upgrade) for more information. Please note that we do not use all of Laravel.
 - Optional params in url generator now work. For instance, the url generator can now properly generate links to posts in discussions.
-- A User Extender has been added, which replaces the deprecated `PrepareUserGroups` and `GetDisplayName` eventss
+- A User Extender has been added, which replaces the deprecated `PrepareUserGroups` and `GetDisplayName` events.
 - Error handler middleware can now be manipulated by the middleware extender through the `add`, `remove`, `replace`, etc methods, just like any other middleware.
-- `Flarum/Foundation/Config` and `Flarum/Foundation/Paths` can now be injected where needed; previously their data was accessible through `Flarum/Foundation/Application`
+- `Flarum/Foundation/Config` and `Flarum/Foundation/Paths` can now be injected where needed; previously their data was accessible through `Flarum/Foundation/Application`.
 
 ### Deprecations
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -267,6 +267,27 @@ class CustomComponent extends Component {
 }
 ```
 
+#### attrs() method
+
+Previously, some components would have an attrs() method, which provided an extensible way to provide attrs to the top-level child vnode returned by `view()`. For instance,
+
+```js
+class CustomComponent extends Component {
+  view() {
+    return <div {...this.attrs()}><p>Hello World!</p></div>;
+  }
+
+  attrs() {
+    return {
+      className: 'SomeClass',
+      onclick: () => console.log('click'),
+    };
+  }
+}
+```
+
+Since `this.attrs` is now used for attrs passed in from parent components, `attrs` methods have been renamed to `elementAttrs`.
+
 #### Children and .component
 
 Previously, an element could be created with child elements by passing those in as the `children` prop:

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -467,7 +467,22 @@ Methods for `disabled` and `viewingEnd` have been added to `forum/states/PostStr
 
 #### SearchState and GlobalSearchState
 
-TODO
+As with other components, we no longer store instances of `forum/components/Search`. As such, every `Search` component instance should be paired with a `forum/states/SearchState` instance. 
+
+At the minimum, `SearchState` contains the following methods:
+
+- getValue
+- setValue
+- clear
+- cache (adds a searched value to cache, meaning that we don't need to search for its results again)
+- isCached (checks if a value has been searched for before)
+
+All of these methods have been moved from `Search` to `SearchState`. Additionally, Search's `stickyParams`, `params`, `changeSort`, `getInitialSearch`, and `clearInitialSearch` methods have been moved to `forum/states/GlobalSearchState`, which is now available via `app.search`.
+
+To use a custom search, you'll want to:
+
+1. Possibly create a custom subclass of `SearchState`
+2. Create a custom subclass of `Search`, which overrides the `selectResult` method to handle selecting results as needed by your use case, and modify the `sourceItems` methods to contain the search sources you need.
 
 #### moment -> dayjs
 

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -372,6 +372,8 @@ Various input fields are now stored as [Mithril Streams](https://mithril.js.org/
 
 For `forum/components/TextEditor`, the `setValue`, `moveCursorTo`, `getSelectionRange`, `insertAtCursor`, `insertAt`, `insertBetween`, `replaceBeforeCursor`, `insertBetween` methods have been moved to `forum/components/SuperTextarea`.
 
+Also for `forum/components/TextEditor`, `this.disabled` is no longer used; `disabled` is passed in as an attr instead. It may be accessed externally via `app.composer.body.attrs.disabled`.
+
 Similarly to Modals and Alerts, `app.composer.load` no longer accepts a component instance. Instead, pass in the body class and any attrs. For instance,
 
 ```js

--- a/docs/extend/update-b14.md
+++ b/docs/extend/update-b14.md
@@ -521,9 +521,9 @@ class NewWay extends Component {
 
 ### How to upgrade a component
 
-#### Required changes
+#### Required changes recap
 
-*TODO*
+Each of these changes has been explained above, this is just a recap of major changes for your convenience.
 
 - `view()` -> `view(vnode)`
 - Lifecycle


### PR DESCRIPTION
Let's get this ready so that extension developers can prepare themselves for Beta.14.

Since this will be a relatively complex upgrade for those not familiar with the internals of Mithril and its different versions, let's go above and beyond in helping them understand what needs to be done.

Refs flarum/core#2201.

### Open TODOs:

- [ ] Finish section on backend changes
- [ ] Mention removal of auth-* extensions, see flarum/core#2006