### PR TITLE
Fix chat links to point to discord-redirector

### DIFF
--- a/docs/extend/frontend.md
+++ b/docs/extend/frontend.md
@@ -15,7 +15,7 @@ In order to do this transpilation, you need to be working in a capable environme
 * Node.js and npm ([Download](https://nodejs.org/en/download/))
 * Webpack (`npm install -g webpack`)
 
-This can be tricky because everyone's system is different. From the OS you're using, to the program versions you have installed, to the user access permissions – I get chills just thinking about it! If you run into trouble, ~~tell him I said hi~~ use [Google](https://google.com) to see if someone has encountered the same error as you and found a solution. If not, ask for help from the [Flarum Community](https://discuss.flarum.org) or on the [Discord chat](https://flarum.org/chat/).
+This can be tricky because everyone's system is different. From the OS you're using, to the program versions you have installed, to the user access permissions – I get chills just thinking about it! If you run into trouble, ~~tell him I said hi~~ use [Google](https://google.com) to see if someone has encountered the same error as you and found a solution. If not, ask for help from the [Flarum Community](https://discuss.flarum.org) or on the [Discord chat](https://flarum.org/discord/).
 
 It's time to set up our little JavaScript transpilation project. Create a new folder in your extension called `js`, then pop in a couple of new files:
 
@@ -179,7 +179,7 @@ class Counter extends Component {
   init() {
     this.count = 0;
   }
-  
+
   view() {
     return (
       <div>
@@ -190,7 +190,7 @@ class Counter extends Component {
       </div>
     );
   }
-  
+
   config(isInitialized, context) {
     $element = this.$();
     $button = this.$('button');

--- a/docs/extend/update-b10.md
+++ b/docs/extend/update-b10.md
@@ -3,7 +3,7 @@
 Beta 10 further solidifies the core architecture, offering new extenders as a stable, use-case-driven API for extending Flarum's core. A few small changes may necessitate updates to your extensions to make them compatible with Beta 10. These are detailed below.
 
 ::: tip
-If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/chat/).
+If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/discord/).
 :::
 
 ## Breaking Changes
@@ -38,7 +38,7 @@ If you need help applying these changes or using new features, please start a di
 
 - New, extensible **error handling** stack in the `Flarum\Foundation\ErrorHandling` namespace: The `Registry` maps exceptions to "types" and HTTP status codes, `HttpFormatter` instances turn them into HTTP responses. Finally, `Reporter` instances are notified about unknown exceptions.
   - You can build custom exception classes that will abort the current request (or console command). If they have semantic meaning to your application, they should implement the `Flarum\Foundation\KnownError` interface, which exposes a "type" that is used to render pretty error pages or dedicated error messages.
-  - More consistent use of HTTP 401 and 403 status codes. HTTP 401 should be used when logging in (i.e. authenticating) could make a difference; HTTP 403 is reserved for requests that fail because the already authenticated user is lacking permissions to do something. 
+  - More consistent use of HTTP 401 and 403 status codes. HTTP 401 should be used when logging in (i.e. authenticating) could make a difference; HTTP 403 is reserved for requests that fail because the already authenticated user is lacking permissions to do something.
   - The `assertRegistered()` and `assertPermission()` methods of the `Flarum\User\AssertPermissionTrait` trait have been changed to match above semantics. See [this pull request](https://github.com/flarum/core/pull/1854) for more details.
   - Error views are now determined based on error "type", not on status code (see [bdac88b](https://github.com/flarum/core/commit/bdac88b5733643b9c5dabae9e09a64d9f6e41d58))
 - **Queue support**: This release incorporates Laravel's illuminate/queue package, which allows offloading long-running tasks (such as email sending or regular cleanup jobs) onto a dedicated worker process. These changes are mostly under the hood, the next release(s) will start using the queue system for sending emails. By default, Flarum will use the "sync" queue driver, which executes queued tasks immediately. This is far from ideal and mostly guarantees a hassle-free setups. Production-grade Flarum installs are expected to upgrade to a more full-featured queue adapter.

--- a/docs/extend/update-b12.md
+++ b/docs/extend/update-b12.md
@@ -4,7 +4,7 @@ Beta 12 packs several new features for extension developers, but also continues 
  your extensions are affected. We invested extra effort to introduce new functionality in a backward-compatible manner or first deprecate functionality before it will be removed in the next release, in line with our [versioning recommendations](start.md#composer-json).
 
 ::: tip
-If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/chat/).
+If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/discord/).
 :::
 
 ## Deprecations / Upcoming breaking changes

--- a/docs/extend/update-b13.md
+++ b/docs/extend/update-b13.md
@@ -3,7 +3,7 @@
 Beta 13 ships with several new extenders to simplify building and maintaining extensions. We do our best to create backward compatibility changes. We recommend changing to new Extenders as soon as they are available.
 
 ::: tip
-If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/chat/).
+If you need help applying these changes or using new features, please start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/discord/).
 :::
 
 ## Breaking Changes
@@ -32,7 +32,7 @@ If you need help applying these changes or using new features, please start a di
   - [Event extender](https://github.com/flarum/core/pull/2097)
   - [Mail extender](https://github.com/flarum/core/pull/2012)
   - [Model extender](https://github.com/flarum/core/pull/2100)
-  
+
 ## Deprecations
 
 - Several events [have been marked deprecated](https://github.com/flarum/core/commit/4efdd2a4f2458c8703aae654f95c6958e3f7b60b) to be removed in beta 14.

--- a/docs/extend/update-b8.md
+++ b/docs/extend/update-b8.md
@@ -3,7 +3,7 @@
 All extensions will need to be refactored in order to work with beta 8. Here are the main things you will need to do in order to make your extension compatible.
 
 ::: warning
-This guide is not comprehensive. You may encounter some changes we haven't documented. If you need help, start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/chat/).
+This guide is not comprehensive. You may encounter some changes we haven't documented. If you need help, start a discussion on the [community forum](https://discuss.flarum.org/t/extensibility) or [Discord chat](https://flarum.org/discord/).
 :::
 
 ## PHP Namespaces


### PR DESCRIPTION
Hey @luceos 

I've noticed the chat links being broken. Here is a small fix for this. 

(Also automatically fixes trailing spaces)

Cheers!