### PR TITLE
Proposal: Navigation and base font update

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -19,6 +19,7 @@ module.exports = ctx => ({
         apiKey: '8f760cdb850b1e696b72329eed96b01b',
         indexName: 'flarum'
     },
+    searchPlaceholder: 'Search Docs',
 
     docsRepo: 'flarum/docs',
     docsDir: 'docs',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -8,6 +8,10 @@ module.exports = ctx => ({
   plugins: require('./config/plugins'),
   locales: locales.get(),
 
+  head: [
+    ['link', { href: 'https://fonts.googleapis.com/css2?family=Mukta:wght@200;400;600&amp;display=swap', rel: 'stylesheet' }]
+  ],
+
   themeConfig: {
     logo: "/logo-docs.svg",
 

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,6 +1,20 @@
 body
   font-family: "Mukta"
 
+#app
+  .search-box input
+    color #667d99
+    background-color #e7edf3
+    border 2px solid transparent
+    border-radius 4px
+
+    &:focus
+      background-color: #fff;
+      border-color: $accentColor
+    
+    &::placeholder
+      opacity 1
+
 pre.vue-container
   border-left-width: .5rem;
   border-left-style: solid;

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -15,6 +15,12 @@ body
     &::placeholder
       opacity 1
 
+  .nav-links a, a.sidebar-link, .dropdown-title, .sidebar-heading
+    color #667d99
+  
+  a.sidebar-link.active
+    color $accentColor
+
 pre.vue-container
   border-left-width: .5rem;
   border-left-style: solid;

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,3 +1,6 @@
+body
+  font-family: "Mukta"
+
 pre.vue-container
   border-left-width: .5rem;
   border-left-style: solid;

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -1,1 +1,2 @@
 $accentColor = #C84A27
+$textColor = #111


### PR DESCRIPTION
Attemps to match Flarum's brand identity by updating the styles of nav links, search box, base font (Mukta) and base body color.

Before/After:
![compariso](https://user-images.githubusercontent.com/7695608/97660909-a7833880-1a51-11eb-99e8-7437799ffb2f.gif)
