### PR TITLE
config.md: Add site maintenance mode flag

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,7 @@ Here's a quick overview of what everything means with an example file:
 ```php
 <?php return array (
   'debug' => false, // enables or disables debug mode, used to troubleshoot issues
-  'offline' => false, // enables or disables site maintenance mode
+  'offline' => false, // enables or disables site maintenance mode. This makes your site inaccessible to all users (including admins).
   'database' =>
   array (
     'driver' => 'mysql', // the database driver, i.e. MySQL, MariaDB...

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,7 @@ Here's a quick overview of what everything means with an example file:
 ```php
 <?php return array (
   'debug' => false, // enables or disables debug mode, used to troubleshoot issues
+  'offline' => false, // enables or disables site maintenance mode
   'database' =>
   array (
     'driver' => 'mysql', // the database driver, i.e. MySQL, MariaDB...


### PR DESCRIPTION
It is possible to enable or disable site maintenance mode with `offline` key in [config.php](https://github.com/flarum/core/blob/c119731e652fcfb96e1bb410e0550c6fbb3dc445/src/Foundation/Config.php#L42) but this was not documented. This PR adds this missing key into the docs.