### PR TITLE
Add 1.0 Upgrade guide to sidebar

### DIFF
--- a/docs/.vuepress/config/locales/en/sidebar.js
+++ b/docs/.vuepress/config/locales/en/sidebar.js
@@ -56,6 +56,7 @@ module.exports = {
       title: 'Update Guides',
       collapsable: false,
       children: [
+        'update-1.0',
         'update-b16',
         'update-b15',
         'update-b14',


### PR DESCRIPTION
We forgot to add this in the last PR.

Couldn't push to master because of the approval restriction.