### PR TITLE
Fix unexpected codeblock in i18n

### DIFF
--- a/docs/extend/i18n.md
+++ b/docs/extend/i18n.md
@@ -211,7 +211,6 @@ Support for grammatical gender will be added in a future version of Flarum. Deta
 Translation is generally handled by Flarum's front-end client. However, you can use translations in your PHP code if you need to.
 
 First, you'll need to get an instance of the `Flarum\Locale\Translator` class. You'll usually do this by typehinting this class in the constructor of your class so a translator instance is injected by the [IoC Container](https://laravel.com/docs/8.x/container). If dependency injection is not available, you can use `resolve(Translator::class)`. Don't forget a `use Flarum\Locale\Translator;` statement at the top of your PHP file!
-```
 
 Then, the API is similar to the JavaScript Translator class. You can use `$translator->trans` like you'd use `app.translator.trans` in JavaScript.
 You can learn more about the Translator's methods in [Symfony's `Translator` documentation](https://symfony.com/doc/5.2/translation/message_format.html), which Flarum's `Translator` extends.


### PR DESCRIPTION
This is currently the docs, with an unexpected codeblock which also erases the title of other section.

![image](https://user-images.githubusercontent.com/3594924/123635219-b823c280-d81b-11eb-9b73-e2e4a5d82af0.png)
