### PR TITLE
Rename getSender with getFromUser

### DIFF
--- a/docs/extend/notifications.md
+++ b/docs/extend/notifications.md
@@ -8,8 +8,8 @@ Flarum includes a powerful notification system to alert users to new activity.
 
 To define a notification type, you will need to create a new class which implements `Flarum\Notification\Blueprint\BlueprintInterface`. This class will define your notification's content and behaviour through the following methods:
 
+* `getFromUser()` The `User` model for the user that triggered the notification.
 * `getSubject()` The model that the notification is about (eg. the `Post` that was liked).
-* `getSender()` The `User` model for the user that triggered the notification.
 * `getData()` Any other data you might wish to include for access on the frontend (eg. the old discussion title when renamed).
 * `getType()` This is where you name your notification, this will be important for later steps.
 * `getSubjectModal()`: Specify the type of model the subject is (from `getSubject`).
@@ -42,7 +42,7 @@ class PostLikedBlueprint implements BlueprintInterface
         return $this->post;
     }
 
-    public function getSender()
+    public function getFromUser()
     {
         return $this->user;
     }
@@ -304,7 +304,7 @@ export default class NewPostNotification extends Notification {
   }
 
   content() {
-    return app.translator.trans('flarum-subscriptions.forum.notifications.new_post_text', {user: this.attrs.notification.sender()});
+    return app.translator.trans('flarum-subscriptions.forum.notifications.new_post_text', {user: this.attrs.notification.fromUser()});
   }
 }
 ```


### PR DESCRIPTION
I noticed the documentation isn't up to date with the interface. `getSender` was renamed to `getFromUser` 3 years ago.

There are some other things I noticed...

I ordered the description in the order they come up with in the interface, but the order in the example isn't the same. But since the example is copy-pasted as-it from the source it's also the wrong order in the source. Not sure if I should change the order here to match with the interface to make it easier to read? But then should we also update the source code?

I also noticed the javascript example have updated imports, but the actual files don't have it. For instance I wanted to copy the new version of https://github.com/flarum/subscriptions/blob/master/js/src/forum/components/NewPostNotification.js but it doesn't actually have the `forum` and `common` namespace in the source, but already has it here... Not sure what our plan is with those.