### PR TITLE
Document Flarum CLI

### DIFF
--- a/docs/extend/README.md
+++ b/docs/extend/README.md
@@ -10,12 +10,6 @@ This approach makes Flarum extremely customizable. A user can disable any featur
 
 In order to achieve this extensibility, Flarum has been built with rich APIs and extension points. With some programming knowledge, you can leverage these APIs to add just about any feature you want. This section of the documentation aims to teach you how Flarum works, and how to use the APIs so that you can build your own extensions.
 
-:::caution
-
-**Both the Extension API and this documentation is a work in progress.** Be aware that future beta releases may break your extensions! If you have feedback, [we'd love to hear it](https://discuss.flarum.org/).
-
-:::
-
 ## Core vs. Extensions
 
 Where do we draw the line between Flarum's core and its extensions? Why are some features included in the core, and others aren't? It is important to understand this distinction so that we can maintain consistency and quality within Flarum's ecosystem.

--- a/docs/extend/README.md
+++ b/docs/extend/README.md
@@ -26,13 +26,13 @@ If you are aiming to address a bug or shortcoming of the core, or of an existing
 
 - [This Documentation](start.md)
 - [Tips for Beginning Developers](https://discuss.flarum.org/d/5512-extension-development-tips)
+- [Flarum CLI](https://github.com/flarum/cli)
 - [Developers explaining their workflow for extension development](https://discuss.flarum.org/d/6320-extension-developers-show-us-your-workflow)
 - [Extension namespace tips](https://discuss.flarum.org/d/9625-flarum-extension-namespacing-tips)
 - [Mithril js documentation](https://mithril.js.org/)
 - [Laravel API Docs](https://laravel.com/api/8.x/)
 - [Flarum API Docs](https://api.flarum.org)
 - [ES6 cheatsheet](https://github.com/DrkSephy/es6-cheatsheet)
-- [Flarum Blank Extension Generator](https://discuss.flarum.org/d/11333-flarum-extension-generator-by-reflar/)
 
 ### Getting help
 

--- a/docs/extend/api.md
+++ b/docs/extend/api.md
@@ -55,6 +55,15 @@ Also, remember that route names (`tags.index`, `tags.show`, etc) must be unique!
 
 The `Flarum\Api\Controller` namespace contains a number of abstract controller classes that you can extend to easily implement your JSON-API resources.
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically create your endpoint controllers:
+```bash
+$ flarum-cli make backend api-controller
+```
+
+:::
+
 ### Listing Resources
 
 For the controller that lists your resource, extend the `Flarum\Api\Controller\AbstractListController` class. At a minimum, you need to specify the `$serializer` you want to use to serialize your models, and implement a `data` method to return a collection of models. The `data` method accepts the `Request` object and the tobscure/json-api `Document`.
@@ -285,6 +294,15 @@ class DiscussionSerializer extends AbstractSerializer
     }
 }
 ```
+
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically create your serializer:
+```bash
+$ flarum-cli make backend api-serializer
+```
+
+:::
 
 ### Attributes and Relationships
 

--- a/docs/extend/authorization.md
+++ b/docs/extend/authorization.md
@@ -91,6 +91,15 @@ Then, we check if the policy class has a method called `can`. If so, we run it w
 
 If `can` doesn't exist or returns null, we are done with this policy, and we proceed to the next one.
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically generate policies:
+```bash
+$ flarum-cli make backend policy
+```
+
+:::
+
 ### Example Policies
 
 Let's take a look at an example policy from [Flarum Tags](https://github.com/flarum/tags/blob/master/src/Access):

--- a/docs/extend/backend-events.md
+++ b/docs/extend/backend-events.md
@@ -4,6 +4,16 @@ Often, an extension will want to react to some events occuring elsewhere in Flar
 
 For a full list of backend events, see our [API documentation](https://api.docs.flarum.org/php/master/search.html?search=Event). Domain events classes are organized by namespace, usually `Flarum\TYPE\Event`.
 
+
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically generate event listeners:
+```bash
+$ flarum-cli make backend event-listener
+```
+
+:::
+
 ## Listening to Events
 
 You can attach a listener to an event using the [`Event`](https://api.docs.flarum.org/php/master/flarum/extend/event) [extender](start.md#extenders):
@@ -17,25 +27,25 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 return [
     (new Extend\Event)
         ->listen(Deleted::class, function($event) {
-          // do something here
+            // do something here
         })
         ->listen(Deleted::class, PostDeletedListener::class)
 ];
-
-
+```
+```php
 class PostDeletedListener
 {
-  protected $translator;
+    protected $translator;
 
-  public function __construct(TranslatorInterface $translator)
-  {
-      $this->translator = $translator;
-  }
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
 
-  public function handle(Deleted $event)
-  {
-    // Your logic here
-  }
+    public function handle(Deleted $event)
+    {
+        // Your logic here
+    }
 }
 ```
 
@@ -54,32 +64,32 @@ return [
     (new Extend\Event)
         ->subscribe(PostEventSubscriber::class),
 ];
-
-
+```
+```php
 class PostEventSubscriber
 {
-  protected $translator;
-
-  public function __construct(TranslatorInterface $translator)
-  {
-      $this->translator = $translator;
-  }
-
-  public function subscribe($events)
-  {
-    $events->listen(Deleted::class, [$this, 'handleDeleted']);
-    $events->listen(Saving::class, [$this, 'handleSaving']);
-  }
-
-  public function handleDeleted(Deleted $event)
-  {
-    // Your logic here
-  }
-
-  public function handleSaving(Saving $event)
-  {
-    // Your logic here
-  }
+    protected $translator;
+  
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+  
+    public function subscribe($events)
+    {
+        $events->listen(Deleted::class, [$this, 'handleDeleted']);
+        $events->listen(Saving::class, [$this, 'handleSaving']);
+    }
+  
+    public function handleDeleted(Deleted $event)
+    {
+        // Your logic here
+    }
+  
+    public function handleSaving(Saving $event)
+    {
+        // Your logic here
+    }
 }
 ```
 
@@ -111,7 +121,7 @@ class SomeClass
     {
         // Logic
         $this->events->dispatch(
-        new Deleted($somePost, $someActor)
+            new Deleted($somePost, $someActor)
         );
         // More Logic
     }

--- a/docs/extend/backend-events.md
+++ b/docs/extend/backend-events.md
@@ -2,12 +2,6 @@
 
 Often, an extension will want to react to some events occuring elsewhere in Flarum. For instance, we might want to increment a counter when a new discussion is posted, send a welcome email when a user logs in for the first time, or add tags to a discussion before saving it to the database. These events are known as **domain events**, and are broadcasted across the framework through [Laravel's event system](https://laravel.com/docs/8.x/events).
 
-:::warning Old Event API
-
-Historically, Flarum has used events for its extension API, emitting events like `GetDisplayName` or `ConfigureApiRoutes` to allow extensions to insert logic into various parts of Flarum. These events are gradually being phased out in favor of the declarative [extender system](start.md#extenders), and will be removed before stable. Domain events will not be removed.
-
-:::
-
 For a full list of backend events, see our [API documentation](https://api.docs.flarum.org/php/master/search.html?search=Event). Domain events classes are organized by namespace, usually `Flarum\TYPE\Event`.
 
 ## Listening to Events

--- a/docs/extend/console.md
+++ b/docs/extend/console.md
@@ -24,6 +24,15 @@ class YourCommand extends AbstractCommand {
 }
 ```
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically generate and register a console command:
+```bash
+$ flarum-cli make backend command
+```
+
+:::
+
 ## Registering Console Commands
 
 To register console commands, use the `Flarum\Extend\Console` extender in your extension's `extend.php` file:

--- a/docs/extend/frontend.md
+++ b/docs/extend/frontend.md
@@ -19,7 +19,7 @@ Along with new TypeScript support, we have a [`tsconfig` package](https://www.np
 
 ## Transpilation and File Structure
 
-This portion of the guide will explain the necessary file setup for extensions. Once again, we highly recommend using the unofficial [FoF extension generator](https://github.com/FriendsOfFlarum/extension-generator) to set up the file structure for you. That being said, you should still read this to understand what's going on beneath the surface.
+This portion of the guide will explain the necessary file setup for extensions. Once again, we highly recommend using the [Flarum CLI](https://github.com/flarum/cli) to set up the file structure for you. That being said, you should still read this to understand what's going on beneath the surface.
 
 Before we can write any JavaScript, we need to set up a **transpiler**. This allows us to use [TypeScript](https://www.typescriptlang.org/) and its magic in Flarum core and extensions.
 

--- a/docs/extend/interactive-components.md
+++ b/docs/extend/interactive-components.md
@@ -64,6 +64,15 @@ export default class CustomModal extends Modal {
 
 More information about methods available to override is available in our [API documentation](https://api.docs.flarum.org/js/master/class/src/common/components/modal.js~modal).
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically generate a modal:
+```bash
+$ flarum-cli make frontend modal
+```
+
+:::
+
 ## Composer
 
 Since Flarum is a forum, we need tools for users to be able to create and edit posts and discussions. Flarum accomplishes this through the floating composer component.

--- a/docs/extend/models.md
+++ b/docs/extend/models.md
@@ -12,6 +12,16 @@ Before we delve into implementation details, let's define some key concepts.
 
 **Models** provide a convenient, code-based API for creating, reading, updating, and deleting data. On the backend, they are represented by PHP classes, and are used to interact with the MySQL database. On the frontend, they are represented by JS classes, and are used to interact with the [JSON:API](api.md), which we'll discuss in the next article.
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically create your model:
+```bash
+$ flarum-cli make backend model
+$ flarum-cli make frontend model
+```
+
+:::
+
 ## Migrations
 
 If we want to use a custom model, or add attributes to an existing one, we will need to modify the database to add tables / columns. We do this via migrations.

--- a/docs/extend/routes.md
+++ b/docs/extend/routes.md
@@ -36,6 +36,15 @@ return [
 ];
 ```
 
+:::info [Flarum CLI](https://github.com/flarum/cli)
+
+You can use the CLI to automatically generate your routes:
+```bash
+$ flarum-cli make backend route
+```
+
+:::
+
 ### Controllers
 
 In Flarum, **Controller** is just another name for a class that implements [RequestHandlerInterface](https://github.com/php-fig/http-server-handler/blob/master/src/RequestHandlerInterface.php). Put simply, a controller must implement a `handle` method which receives a [Request](https://github.com/php-fig/http-message/blob/master/src/ServerRequestInterface.php) and must return a [Response](https://github.com/php-fig/http-message/blob/master/src/ResponseInterface.php). Flarum includes [laminas-diactoros](https://github.com/laminas/laminas-diactoros) which contains `Response` implementations that you can return.

--- a/docs/extend/start.md
+++ b/docs/extend/start.md
@@ -127,9 +127,12 @@ We need to tell Composer a bit about our package, and we can do this by creating
 
 See [the composer.json schema](https://getcomposer.org/doc/04-schema.md) documentation for information about other properties you can add to `composer.json`.
 
-:::tip
+:::info [Flarum CLI](https://github.com/flarum/cli)
 
-Use the [FoF extension generator](https://github.com/FriendsOfFlarum/extension-generator) to automatically create your extension's scaffolding.
+Use the CLI to automatically create your extension's scaffolding:
+```bash
+$ flarum-cli init
+```
 
 :::
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -1,4 +1,4 @@
-module.exports = { 
+module.exports = {
   guideSidebar: [
     {
       type: 'category',


### PR DESCRIPTION
At first I only changed the references to fof extension generator and added a `cli.md` but I don't know if we need a dedicated docs page, instead I added references to commands in each section, similar to how Laravel's docs mention the appropriate artisan commands.