### PR TITLE
1.1 upgrade guide

### DIFF
--- a/docs/extend/update-1_x.md
+++ b/docs/extend/update-1_x.md
@@ -22,4 +22,4 @@ Flarum version 1.1 mostly focuses on bugfixes and quality-of-life improvements f
 ### Backend
 
 - Flarum now comes with a [Preload extender](https://github.com/flarum/core/pull/3057) for preloading any custom frontend assets.
-- A new [Theme](https://github.com/flarum/core/pull/3008) extender now allows overriding LESS files and internal imports. This allows themes to more easily completely replace LESS modules.
+- A new [Theme](https://github.com/flarum/core/pull/3008) extender now allows overriding Less files and internal imports. This allows themes to more easily completely replace Less modules.


### PR DESCRIPTION
I added a page with all the 1.x upgrade guides, as we should probably only have full-page guides for breaking releases. The guide summarizes changes impacting developers from https://github.com/flarum/org/issues/135.