### PR TITLE
typo: `crowin` -> `Crowdin`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
 <!--
-IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that crowin will fail to sync your changes, and your work will be lost.
+IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that Crowdin will fail to sync your changes, and your work will be lost.
 Instead, please follow the instructions at https://docs.flarum.org/contributing-docs-translations.
 -->


### PR DESCRIPTION
<!--
IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that crowin will fail to sync your changes, and your work will be lost.
Instead, please follow the instructions at https://docs.flarum.org/contributing-docs-translations.
-->