### PR TITLE
docs: use Illuminate Str support func

### DIFF
--- a/docs/extend/api.md
+++ b/docs/extend/api.md
@@ -122,11 +122,15 @@ You can allow the sort order of resources being **listed** to be customized by s
 You can then extract sorting information from the request using the `extractSort` method. This will return an array of sort criteria which you can apply to your query:
 
 ```php
+use Illuminate\Support\Str;
+
+// ...
+
 $sort = $this->extractSort($request);
 $query = Tag::query();
 
 foreach ($sort as $field => $order) {
-    $query->orderBy(snake_case($field), $order);
+    $query->orderBy(Str::snake($field), $order);
 }
 
 return $query->get();


### PR DESCRIPTION
`snake_case()`  doesn't seem defined when you try and use it. This seems like a better solution.

<!--
IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that Crowdin will fail to sync your changes, and your work will be lost.
Instead, please follow the instructions at https://docs.flarum.org/contributing-docs-translations.
-->
