### PR TITLE
Document conventional commits specification & tweak merging process considerations.

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -96,7 +96,8 @@ A typical contribution workflow looks like this:
 
 4. 💾 **Commit** your code with a descriptive message.
     * If your change resolves an existing issue (usually, it should) include "Fixes #123" on a newline, where 123 is the issue number.
-    * Write a [good commit message](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+    * Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
+    * *Fix* commits should describe the issue fixed, not the fix.
 
 5. 🎁 **Submit** a Pull Request on GitHub.
     * Fill out the pull request template.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -97,7 +97,7 @@ A typical contribution workflow looks like this:
 4. 💾 **Commit** your code with a descriptive message.
     * If your change resolves an existing issue (usually, it should) include "Fixes #123" on a newline, where 123 is the issue number.
     * Follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specification.
-    * *Fix* commits should describe the issue fixed, not the fix.
+    * *Fix* commits should describe the issue fixed, not how it was fixed.
 
 5. 🎁 **Submit** a Pull Request on GitHub.
     * Fill out the pull request template.

--- a/docs/internal/merging.md
+++ b/docs/internal/merging.md
@@ -15,13 +15,15 @@ If all of the checks in the template are met, **any** core developer may merge t
 - Merging:
   - GitHub offers several ways to merge a PR. Choose between the following strategies:
     - **Merge** when the PR branch consists of atomic, well-described commits that are nice to have in the version history.
-    - **Squash** when lots of cleanup commits have accumulated. Please make sure to write a [good commit message](https://chris.beams.io/posts/git-commit/) for the squash commit.
+    - **Squash** when lots of cleanup commits have accumulated. Please make sure to follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) spec for the squash commit.
 
 - After merging:
-  - Make sure the *issue* (if none exists, the PR - but not both) belongs to the appropriate milestone. PRs in extensions cannot be assigned to core milestones, so assign it to the current release's project board instead.
+  - Make sure the *issue* (if none exists, the PR - but not both) belongs to the appropriate milestone and project board.
+  - PRs in extensions cannot be assigned to core milestones, so create a core issue that references it and add it to the milestone.
   - Close all relevant issues (*if* they are closed completely).
+  - Regressions should be labeled as such and removed from the project board and milestone after merging.
   - Check for follow-up tasks:
-    - Merge related PRs (language files, extensions, documentations)
-    - Documentation updates
+    - Merge related PRs (language files, extensions, documentations).
+    - Documentation updates.
   - Create issues for further follow-up tasks, if necessary.
 


### PR DESCRIPTION
**Changes Suggested**
- Officially switch to using the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#specification) specification, this will make changelog generation a lot easier through automation, but also makes the commit history more readable.
  - With the one custom difference being, describing the actual issue instead of the fix, when it comes to fix commits, as suggested by Daniël, this is better for the changelog.
- Tweak the merging process considerations
  - I don't believe we want regressions added to the milestone/project board.
  - I also believe we've taken the habit of creating issues in `core` that reference PRs in extensions that are added to the milestone. Although this won't matter once we switch to monorepo.
