### PR TITLE
[en] Add missing i18n code & Delete duplicate url

### DIFF
--- a/docs/composer.md
+++ b/docs/composer.md
@@ -17,7 +17,7 @@ Historically, Composer has caused issues on shared hosting due to huge memory us
 
 ## What is Composer?
 
-> Composer is a tool for dependency management in PHP. It allows you to declare the libraries your project depends on and it will manage (install/update) them for you. — [Composer Introduction](https://getcomposer.org/doc/00-intro.md](https://getcomposer.org/doc/00-intro.md))
+> Composer is a tool for dependency management in PHP. It allows you to declare the libraries your project depends on and it will manage (install/update) them for you. — [Composer Introduction](https://getcomposer.org/doc/00-intro.md)
 
 Each Flarum installation consists primarily of Flarum core and a set of [extensions](extensions.md). Each of these has its own dependencies and releases.
 

--- a/i18n/en/docusaurus-plugin-content-docs/current.json
+++ b/i18n/en/docusaurus-plugin-content-docs/current.json
@@ -7,6 +7,10 @@
     "message": "Introduction",
     "description": "The label for category Introduction in sidebar guideSidebar"
   },
+  "sidebar.guideSidebar.category.Contribute": {
+    "message": "Contribute",
+    "description": "The label for category Contribute in sidebar guideSidebar"
+  },
   "sidebar.guideSidebar.category.Setting Up": {
     "message": "Setting Up",
     "description": "The label for category Setting Up in sidebar guideSidebar"


### PR DESCRIPTION
1. There is no `contribute` Category i18n code in English json file, so neither does Crowdin.

2. A duplicate url of `Composer Introduction` needs to be deleted.