### PR TITLE
Add PHP fileinfo module to requirements

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@ Feel free to give Flarum a spin on one of our [demonstration forums](https://dis
 Before you install Flarum, it's important to check that your server meets the requirements. To run Flarum, you will need:
 
 * **Apache** (with mod\_rewrite enabled) or **Nginx**
-* **PHP 7.3+** with the following extensions: curl, dom, gd, json, mbstring, openssl, pdo\_mysql, tokenizer, zip
+* **PHP 7.3+** with the following extensions: curl, dom, fileinfo, gd, json, mbstring, openssl, pdo\_mysql, tokenizer, zip
 * **MySQL 5.6+/8.0.23+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run Composer
 


### PR DESCRIPTION
Composer else fails with:
```
  Problem 1
    - intervention/image[2.5.0, ..., 2.7.1] require ext-fileinfo * -> it is missing from your system. Install or enable PHP's fileinfo extension.
```
The module was probably accidentally lost with this commit: https://github.com/flarum/docs/commit/6519789