### PR TITLE
Fix Caddy example

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -67,7 +67,7 @@ Caddy requires a very simple configuration in order for Flarum to work properly.
 www.example.com {
     root * /var/www/flarum/public
     php_fastcgi unix//var/run/php/php7.4-fpm.sock
-    header /assets {
+    header /assets* {
         +Cache-Control "public, must-revalidate, proxy-revalidate"
         +Cache-Control "max-age=25000"
         Pragma "public"

--- a/docs/install.md
+++ b/docs/install.md
@@ -67,7 +67,7 @@ Caddy requires a very simple configuration in order for Flarum to work properly.
 www.example.com {
     root * /var/www/flarum/public
     php_fastcgi unix//var/run/php/php7.4-fpm.sock
-    header /assets* {
+    header /assets/* {
         +Cache-Control "public, must-revalidate, proxy-revalidate"
         +Cache-Control "max-age=25000"
         Pragma "public"


### PR DESCRIPTION
Request matchers in Caddy are exact, so `/assets` would only match requests to exactly `/assets` but not `/assets/app.js` etc. Using the `*` is necessary to match all requests to files within that directory. See https://caddyserver.com/docs/caddyfile/matchers#path-matchers

<!--
IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that Crowdin will fail to sync your changes, and your work will be lost.
Instead, please follow the instructions at https://docs.flarum.org/contributing-docs-translations.
-->
