### PR TITLE
Update troubleshooting guide with debug instructions

### DIFF
--- a/versioned_docs/version-1.x/troubleshoot.md
+++ b/versioned_docs/version-1.x/troubleshoot.md
@@ -14,6 +14,7 @@ These are fine if you're on a staging or development environment, but if you don
 :::
 
 Before you proceed, you should enable Flarum's debugging tools. Simply open up **config.php** with a text editor, change the `debug` value to `true`, and save the file. This will cause Flarum to display detailed error messages, giving you an insight into what's going wrong.
+To disable debug you can change the `debug` value back to `false`, and save the file.
 
 If you've been seeing blank pages and the above change doesn't help, try setting `display_errors` to `On` in your **php.ini** configuration file.
 


### PR DESCRIPTION
Added instructions to disable debugging in Flarum. The admin area recommends disabling debug in production, but the documentation does not explain how to do this. For anyone who has or had their debug enabled, they would have no idea on how to disable this feature in general.

<!--
IMPORTANT: Please do NOT contribute translations via GitHub pull requests! It is very likely that Crowdin will fail to sync your changes, and your work will be lost.
Instead, please follow the instructions at https://docs.flarum.org/contributing-docs-translations.
-->
