### PR TITLE
docs: update testing guide for PHPUnit 12

### DIFF
--- a/docs/extend/testing.md
+++ b/docs/extend/testing.md
@@ -40,19 +40,19 @@ tests
 
 #### phpunit.integration.xml
 
-This is just an example [phpunit config file](https://phpunit.readthedocs.io/en/9.3/configuration.html) for integration tests. You can tweak this as needed, but keep `backupGlobals`, `backupStaticAttributes`, and `processIsolation` unchanged.
+This is just an example [phpunit config file](https://docs.phpunit.de/en/12.5/configuration.html) for integration tests. You can tweak this as needed, but keep `backupGlobals`, `backupStaticProperties`, and `processIsolation` unchanged.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="true"
-         stopOnFailure="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticProperties="false"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    processIsolation="true"
+    stopOnFailure="false">
 
     <testsuites>
         <testsuite name="Flarum Integration Tests">
@@ -64,30 +64,33 @@ This is just an example [phpunit config file](https://phpunit.readthedocs.io/en/
 
 #### phpunit.unit.xml
 
-This is just an example [phpunit config file](https://phpunit.readthedocs.io/en/9.3/configuration.html) for unit tests. You can tweak this as needed.
+This is just an example [phpunit config file](https://docs.phpunit.de/en/12.5/configuration.html) for unit tests. You can tweak this as needed.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
+    backupGlobals="false"
+    backupStaticProperties="false"
+    cacheDirectory=".phpunit.cache"
+    colors="true"
+    processIsolation="false"
+    stopOnFailure="false">
 
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener"></listener>
-    </listeners>
 </phpunit>
 ```
+
+:::note
+
+As of Flarum 2.x, `flarum/testing` requires PHPUnit 12. Example configs above reflect PHPUnit 12's schema — the legacy `convertErrorsToExceptions`, `convertNoticesToExceptions`, `convertWarningsToExceptions`, and `backupStaticAttributes` attributes were removed in PHPUnit 10, and the `<listeners>` element was removed in PHPUnit 10. If you're migrating an extension from Flarum 1.x, replace any `@test` / `@dataProvider` docblock annotations with the PHP 8 attribute equivalents (`#[Test]`, `#[DataProvider]`) — docblock annotations no longer register tests. See the [PHPUnit annotations guide](https://docs.phpunit.de/en/12.5/annotations.html) for the full list.
+
+:::
 
 #### setup.php
 
@@ -188,6 +191,7 @@ namespace CoolExtension\Tests\integration;
 
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SomeTest extends TestCase
 {
@@ -222,9 +226,7 @@ class SomeTest extends TestCase
         $this->extend((new CoolExtensionExtender)->doSomething('hello world'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function some_phpunit_test_case()
     {
         // ...
@@ -283,13 +285,13 @@ namespace CoolExtension\Tests\integration;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
 
 class SomeTest extends TestCase
 {
     use RetrievesAuthorizedUsers;
-    /**
-     * @test
-     */
+
+    #[Test]
     public function some_phpunit_test_case()
     {
         $this->app();
@@ -363,12 +365,11 @@ For example:
 namespace CoolExtension\Tests\integration;
 
 use Flarum\Testing\integration\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class SomeTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function can_search_users()
     {
         $response = $this->send(
@@ -379,9 +380,7 @@ class SomeTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function can_create_user()
     {
         $response = $this->send(
@@ -444,12 +443,11 @@ For example:
 namespace CoolExtension\Tests\integration;
 
 use Flarum\Tests\integration\ConsoleTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConsoleTest extends ConsoleTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function command_works()
     {
         $input = [
@@ -465,7 +463,7 @@ class ConsoleTest extends ConsoleTestCase
 
 ### Using Unit Tests
 
-Unit testing in Flarum uses [PHPUnit](https://phpunit.de/getting-started/phpunit-9.html) and so unit testing in flarum is much like any other PHP application. You can find [general tutorials on testing](https://www.youtube.com/watch?v=9-X_b_fxmRM) if you're also new to php.
+Unit testing in Flarum uses [PHPUnit](https://phpunit.de/) and so unit testing in flarum is much like any other PHP application. You can find [general tutorials on testing](https://www.youtube.com/watch?v=9-X_b_fxmRM) if you're also new to php.
 
 When writing unit tests in Flarum, here are some helpful tips.
 

--- a/docs/extend/update-2_0.md
+++ b/docs/extend/update-2_0.md
@@ -577,6 +577,80 @@ If your extension uses Larastan's template type annotations, two names have chan
 * `TModelClass` → `TModel`
 * `TChildModel` → `TDeclaringModel`
 
+### PHPUnit (updated from ^9.5 to ^12.5)
+
+Flarum 2.0 upgrades `flarum/testing` to PHPUnit 12. PHPUnit 12 requires PHP 8.3+ (already the 2.x floor) and removes docblock annotation support, so extension test suites need to migrate to PHP 8 attributes.
+
+#### Annotations replaced by attributes
+
+##### <span class="breaking">Breaking</span>
+
+Docblock annotations like `@test`, `@dataProvider`, `@depends`, `@before`, `@after`, `@group`, `@covers`, and `@runInSeparateProcess` are no longer recognised. Tests that relied on `@test` to mark methods without a `test` prefix will **silently stop being discovered** — PHPUnit will not warn you.
+
+Replace them with their PHP 8 attribute equivalents:
+
+```php
+// Before
+use PHPUnit\Framework\TestCase;
+
+class MyTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideFoo
+     */
+    public function it_works(int $input): void
+    {
+        // ...
+    }
+
+    public static function provideFoo(): array
+    {
+        return [[1], [2]];
+    }
+}
+
+// After
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class MyTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('provideFoo')]
+    public function it_works(int $input): void
+    {
+        // ...
+    }
+
+    public static function provideFoo(): array
+    {
+        return [[1], [2]];
+    }
+}
+```
+
+See the [PHPUnit annotations guide](https://docs.phpunit.de/en/12.5/annotations.html) for the full mapping. [Rector](https://github.com/rectorphp/rector) ships a ruleset (`PHPUnitSetList::ANNOTATIONS_TO_ATTRIBUTES`) that automates the conversion.
+
+#### phpunit.xml schema changes
+
+##### <span class="breaking">Breaking</span>
+
+Several attributes were removed from the PHPUnit config schema between 9.x and 12.x. If your `phpunit.unit.xml` / `phpunit.integration.xml` contains any of these, PHPUnit 12 will fail to load the config:
+
+* `convertErrorsToExceptions`, `convertNoticesToExceptions`, `convertWarningsToExceptions` — removed in PHPUnit 10. Errors, notices, and warnings are always converted to exceptions now.
+* `backupStaticAttributes` — renamed to `backupStaticProperties` in PHPUnit 10.
+* `<listeners>` element — removed in PHPUnit 10. The Mockery `TestListener` is no longer needed; Mockery integrates automatically via PHPUnit's extension mechanism when `mockery/mockery` is installed.
+
+See the updated example configs in the [testing guide](testing.md#phpunitintegrationxml).
+
+#### Mockery expectations
+
+##### <span class="notable">Notable</span>
+
+PHPUnit 12 emits a notice for every mock that is created without any expectations configured (`No expectations were configured for the mock object ...`). These are advisory and do not fail the suite, but they indicate tests that would be clearer using a stub instead of a mock. To silence the notice for a specific test class or method without changing the mock, add the `#[AllowMockObjectsWithoutExpectations]` attribute.
+
 ### Reusable GitHub Workflows
 
 ##### <span class="breaking">Breaking</span>


### PR DESCRIPTION
## Summary
- Refresh [docs/extend/testing.md](docs/extend/testing.md) example PHPUnit configs and test examples for PHPUnit 12.
- Add a **PHPUnit** section to [docs/extend/update-2_0.md](docs/extend/update-2_0.md) covering the 9.x → 12.x jump.

## Why

Companion to flarum/framework#4585, which bumps \`flarum/testing\`'s PHPUnit constraint from \`^11.0\` to \`^12.5.22\` to clear GHSA-qrr6-mg7r-m243. The existing docs still show PHPUnit 9-era configs and \`@test\` docblock annotations — both broken on PHPUnit 10+, and silently broken on PHPUnit 12 (docblock annotations stop registering tests without warning).

## testing.md

- Example \`phpunit.integration.xml\` / \`phpunit.unit.xml\` configs rewritten for the PHPUnit 12 schema (drop removed \`convertErrorsToExceptions\` / \`convertNoticesToExceptions\` / \`convertWarningsToExceptions\`, rename \`backupStaticAttributes\` → \`backupStaticProperties\`, drop the \`<listeners>\` block, add schema declaration and \`cacheDirectory\`).
- All five \`@test\` docblock examples converted to \`#[Test]\` attributes with the matching \`use PHPUnit\\Framework\\Attributes\\Test;\` import.
- Updated PHPUnit documentation links from \`phpunit.readthedocs.io/en/9.3/\` → \`docs.phpunit.de/en/12.5/\`.
- Added a migration callout under the example configs summarising the PHPUnit 12 requirement and pointing at the annotations guide.

## update-2_0.md

- New **PHPUnit (updated from ^9.5 to ^12.5)** subsection under **Infrastructure**, matching the PHPStan/Larastan section's breaking/notable formatting.
- Calls out:
  - Annotations → attributes (with a complete before/after example, note about silent test non-discovery, and pointer to Rector's \`ANNOTATIONS_TO_ATTRIBUTES\` set).
  - Config schema attribute/element removals.
  - PHPUnit 12's new \`AllowMockObjectsWithoutExpectations\` notice (advisory, not breaking).

## Test plan

- [x] Rendered locally — no Docusaurus build errors, admonition renders.
- [ ] Reviewer spot-check that the example XML matches what core's [tests/phpunit.integration.xml](https://github.com/flarum/framework/blob/2.x/framework/core/tests/phpunit.integration.xml) uses.