### PR TITLE
Reframe 2.0 status from beta to release candidate

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,7 +8,7 @@ Feel free to give Flarum a spin on one of our [demonstration forums](https://dis
 
 :::warning
 
-Flarum 2.0 is currently in beta. It is not ready for production use.
+Flarum 2.0 is in its release-candidate phase. The API is stable and many forums already run it in production — but it isn't the final stable release yet, so back up your data and test before relying on it.
 
 :::
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -2,7 +2,7 @@
 
 :::warning
 
-Flarum 2.0 is currently in beta. It is not ready for production use. Please wait for the stable release before updating your forum.
+Flarum 2.0 is in its release-candidate phase. The API is stable and many forums already run it in production. It isn't the final stable release yet, so back up your database and test on a staging copy before upgrading a live forum.
 
 :::
 
@@ -49,7 +49,7 @@ Set the version string of all extensions (including bundled ones like `flarum/ta
 ```
 
 **5. Set `minimum-stability` to `beta`.**
-While Flarum 2.0 is in beta, your `composer.json` must have:
+Until Flarum 2.0 reaches its final stable release, your `composer.json` must allow pre-stable versions:
 
 ```json
 "minimum-stability": "beta"
@@ -57,7 +57,7 @@ While Flarum 2.0 is in beta, your `composer.json` must have:
 
 :::info
 
-Once Flarum 2.0 stable is released, you should change this to `stable`. Leaving it as `beta` after that point can cause Composer to pull in unstable versions of packages unexpectedly.
+Once Flarum 2.0 stable is released, you should change this back to `stable`. Leaving it as `beta` after that point can cause Composer to pull in unstable versions of packages unexpectedly.
 
 :::
 


### PR DESCRIPTION
Flarum 2.0 has moved past beta into its release-candidate phase, but the docs still describe it as "currently in beta" and "not ready for production use." This updates the status prose to match reality.

## Changes

- **install.md** — warning box now states 2.0 is in its release-candidate phase, the API is stable, and many forums run it in production, with a back-up-and-test caution.
- **update.md** — same reframing on the upgrade warning box; step 5 wording changed from "while Flarum 2.0 is in beta" to "until Flarum 2.0 reaches its final stable release"; minor "change this back to `stable`" tidy.

## Not changed

- The Composer stability flags and version constraints (`--stability=beta`, `minimum-stability: beta`, `^2.0.0-beta`) are **left as-is**. `beta` accepts RC and above, so they still resolve correctly, and changing them risks breaking copy-pasted commands. This PR is prose-only.
- Generic stability-ladder docs and historical 1.x beta references are out of scope.