### PR TITLE
Correct 2.x extend reference inaccuracies + add DB version guidance

### DIFF
--- a/docs/extend/admin.md
+++ b/docs/extend/admin.md
@@ -8,26 +8,63 @@ You can register settings, permissions, or use an entirely custom page based off
 
 The admin frontend allows you to add settings and permissions to your extension with very few lines of code, using the `Admin` frontend extender.
 
-To get started, make sure you have an `admin/extend.js` file:
+Register your settings, permissions, and admin page in a declarative `admin/extend.ts` file rather than imperatively inside the `admin/index.ts` initializer. The extender approach is the recommended pattern: it's less code, and — importantly — it lets Flarum automatically index your settings and permissions for the [admin search](#admin-search). Reserve the `index.ts` initializer for logic that genuinely has to run imperatively (e.g. extending core components).
 
-```js
+To get started, create an `admin/extend.ts` file:
+
+```ts
 import Extend from 'flarum/common/extenders';
 import app from 'flarum/admin/app';
 
 export default [
   //
-]
+];
 ```
 
-:::info
+:::warning Don't forget the import
 
-Remember to export the `extend` module from your entry `admin/index.js` file:
+For your extenders to take effect, your entry `admin/index.ts` file **must** re-export the `extend` module:
 
-```js
+```ts
+// admin/index.ts
 export { default as extend } from './extend';
+
+app.initializers.add('acme-interstellar', () => {
+  // Imperative-only logic goes here. Keep your settings, permissions,
+  // and page registration in extend.ts.
+});
 ```
+
+Without this `export` line, none of your extenders run.
 
 :::
+
+A complete `extend.ts` registering a custom admin page alongside settings and a permission looks like this:
+
+```ts
+import Extend from 'flarum/common/extenders';
+import app from 'flarum/admin/app';
+import SettingsPage from './components/SettingsPage';
+
+export default [
+  new Extend.Admin()
+    .page(SettingsPage)
+    .setting(() => ({
+      setting: 'acme-interstellar.coordinates',
+      label: app.translator.trans('acme-interstellar.admin.coordinates_label', {}, true),
+      type: 'boolean',
+    }))
+    .permission(
+      () => ({
+        icon: 'fas fa-rocket',
+        label: app.translator.trans('acme-interstellar.admin.permissions.launch_label'),
+        permission: 'acme-interstellar.launch',
+      }),
+      'moderate',
+      90
+    ),
+];
+```
 
 ### Registering Settings
 
@@ -306,9 +343,9 @@ When a reset is confirmed, a `Flarum\Settings\Event\Reset` event is dispatched o
 
 ### Admin Search
 
-The admin dashboard has a search bar that allows you to quickly find settings and permissions. If you have used the `Admin.settings` and `Admin.permissions` extender methods, your settings and permissions will be automatically indexed and searchable. However, if you have a custom setting, or custom page that structures its content differently, then you must manually add index entries that reference your custom settings.
+The admin dashboard has a search bar that allows you to quickly find settings and permissions. If you have used the `Admin.setting` and `Admin.permission` extender methods, your settings and permissions will be automatically indexed and searchable. However, if you have a custom setting, or custom page that structures its content differently, then you must manually add index entries that reference your custom settings.
 
-To do this, you can use the `Admin.generalIndexItems` extender method. This method takes a callback that returns an array of index items. Each index item is an object with the following properties:
+To do this, you can use the `Admin.generalIndexItems` extender method. This method takes an index type (`'settings'` or `'permissions'`) and a callback that returns an array of index items. Each index item is an object with the following properties:
 
 ```ts
 export type GeneralIndexItem = {
@@ -348,7 +385,7 @@ import app from 'flarum/admin/app';
 
 export default [
   new Extend.Admin()
-    .generalIndexItems(() => [
+    .generalIndexItems('settings', () => [
       {
         id: 'acme-interstellar',
         label: app.translator.trans('acme-interstellar.admin.acme_interstellar_label', {}, true),
@@ -388,18 +425,14 @@ Language packs (extensions with an `extra.flarum-locale` key) are always placed 
 
 ### Available Categories
 
-| Key              | Label          | Icon                    |
-|------------------|----------------|-------------------------|
-| `feature`        | Features       | `fas fa-star`           |
-| `moderation`     | Moderation     | `fas fa-shield-alt`     |
-| `discussion`     | Discussion     | `fas fa-comments`       |
-| `authentication` | Authentication | `fas fa-lock`           |
-| `formatting`     | Formatting     | `fas fa-paragraph`      |
-| `infrastructure` | Infrastructure | `fas fa-server`         |
-| `analytics`      | Analytics      | `fas fa-chart-bar`      |
-| `other`          | Other          | `fas fa-cube`           |
-| `theme`          | Themes         | `fas fa-paint-brush`    |
-| `language`       | Languages      | `fas fa-language`       |
+| Key             | Label         |
+|-----------------|---------------|
+| `feature`       | Features      |
+| `theme`         | Themes        |
+| `forum-widget`  | Forum Widgets |
+| `language`      | Languages     |
+
+Any other declared category that is not registered falls back to the **feature** category. You can register additional categories yourself — see [Registering a Custom Category](#registering-a-custom-category) below.
 
 ### Registering a Custom Category
 
@@ -458,7 +491,11 @@ Flarum reads the `abandoned` field from `vendor/composer/installed.json`, which 
 - If a package is marked abandoned after that point, the warning will not appear until Composer is run again.
 - **Private Packagist, Satis, Toran Proxy, and other custom Composer repositories are fully supported** — Composer writes the `abandoned` field from whatever repository served the package, so the data is repository-agnostic.
 
-Automatic periodic checking via a scheduled task is planned for a future version of Flarum 2.x. Because installations may use private or custom repositories rather than Packagist, the scheduled checker will need to be repository-aware. In preparation for this, Flarum already supports a `flarum.abandoned_overrides` settings key that a future task can write to after querying the appropriate repository API. Its value is a JSON object mapping extension IDs to their abandoned status (`false`, `true`, or a replacement package name string). This decouples the checking logic from core's install-time parsing, and means the override mechanism will work regardless of which Composer repository a package came from.
+Flarum also refreshes abandoned-extension data periodically via a scheduled task. The `extensions:sync-abandoned` console command — registered in `flarum.console.scheduled` with a weekly schedule — fetches the [community-maintained abandoned-extensions list](https://raw.githubusercontent.com/flarum/abandoned-extensions/main/abandoned.json), filters it to your installed packages, and stores the result in the `flarum-core.abandoned_extensions_map` setting. When the `flarum-core.notify_admins_on_abandoned` setting is enabled, scheduled runs email admins about newly flagged extensions. You can also trigger it manually:
+
+```bash
+php flarum extensions:sync-abandoned
+```
 
 :::
 

--- a/docs/extend/api-throttling.md
+++ b/docs/extend/api-throttling.md
@@ -23,6 +23,7 @@ Throttlers will be run on EVERY request, and are responsible for figuring out wh
 
 ```php
 use DateTime;
+use Flarum\Http\RequestUtil;
 use Flarum\Post\Post;
 
 function ($request) {
@@ -30,7 +31,7 @@ function ($request) {
         return;
     }
 
-    $actor = $request->getAttribute('actor');
+    $actor = RequestUtil::getActor($request);
 
     if ($actor->can('postWithoutThrottle')) {
         return false;

--- a/docs/extend/api.md
+++ b/docs/extend/api.md
@@ -267,7 +267,7 @@ public function endpoints(): array
 {
     return [
         Endpoint\Index::make()
-            ->defaultSort('-createdAt'),
+            ->defaultSort('-createdAt')
             ->paginate(),
     ];
 }
@@ -739,7 +739,7 @@ public function fields(): array
             ->countRelation('comments'),
         
         Number::make('avgRevenue')
-            ->avgReation('reports', 'revenue'),
+            ->avgRelation('reports', 'revenue'),
         
         Number::make('revenueSum')
             ->sumRelation('reports', 'revenue'),
@@ -911,7 +911,7 @@ use Flarum\Extend;
 
 return [
     (new Extend\ApiResource(Resource\UserResource::class))
-        ->removeField('email'),
+        ->removeFields(['email']),
 ];
 ```
 
@@ -993,7 +993,7 @@ use Flarum\Extend;
 
 return [
     (new Extend\ApiResource(Resource\UserResource::class))
-        ->removeEndpoint('delete'),
+        ->removeEndpoints(['delete']),
 ];
 ```
 
@@ -1041,7 +1041,7 @@ use Flarum\Extend;
 
 return [
     (new Extend\ApiResource(Resource\UserResource::class))
-        ->removeSort('createdAt'),
+        ->removeSorts(['createdAt']),
 ];
 ```
 
@@ -1060,7 +1060,7 @@ return [
 
 ## Non-Model API Resources
 
-API Resources don't have to correspond to Eloquent models: you can define JSON:API resources for anything. You need to extend the [`Flarum\Api\Rsource\AbstractResource`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/AbstractResource.php) class instead.
+API Resources don't have to correspond to Eloquent models: you can define JSON:API resources for anything. You need to extend the [`Flarum\Api\Resource\AbstractResource`](https://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/AbstractResource.php) class instead.
 For instance, Flarum core uses the [`Flarum\Api\Resource\ForumResource`](hhttps://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/ForumResource.php) to send an initial payload to the frontend. This can include settings, whether the current user can perform certain actions, and other data. Many extensions add data to the payload by extending the fields of `ForumResource`.
 
 ## Programmatically calling an API endpoint

--- a/docs/extend/authorization.md
+++ b/docs/extend/authorization.md
@@ -18,7 +18,7 @@ Each of these is determined by unique criteria: in some cases a flag is sufficie
 
 ## How It Works
 
-Authorization queries are made with 3 parameters, with logic contained in [`Flarum\User\Gate`](https://api.docs.flarum.org/php/master/flarum/user/access/gate):
+Authorization queries are made with 3 parameters, with logic contained in [`Flarum\User\Access\Gate`](https://api.docs.flarum.org/php/master/flarum/user/access/gate):
 
 1. The actor: the user attempting to perform the action
 2. The ability: a string representing the action the actor is attempting

--- a/docs/extend/avatars.md
+++ b/docs/extend/avatars.md
@@ -13,7 +13,7 @@ When Flarum needs to display a user's avatar, it resolves the avatar URL through
 3. **Configured avatar driver** - Call the active driver's `avatarUrl()` method
 4. **Null** - Falls back to default UI avatar (initials)
 
-Your driver is only called when the user has no uploaded avatar or custom URL. This means users can always override your driver by uploading their own avatar. The `$user->avatar_url` accessor handles this resolution automatically. You can check if a user has a custom avatar using `$user->original_avatar_url`.
+Your driver is only called when the user has no uploaded avatar or custom URL. This means users can always override your driver by uploading their own avatar. The `$user->avatar_url` accessor handles this resolution automatically. You can check if a user has uploaded a custom avatar using `$user->has_uploaded_avatar`.
 
 ## Creating a Driver
 

--- a/docs/extend/console.md
+++ b/docs/extend/console.md
@@ -6,9 +6,6 @@ All console command development is done in the backend using PHP. To create a cu
 
 ```php
 use Flarum\Console\AbstractCommand;
-use Psr\Http\Message\ServerRequestInterface;
-use Psr\Http\Server\MiddlewareInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
 class YourCommand extends AbstractCommand {
   protected function configure()
@@ -17,9 +14,11 @@ class YourCommand extends AbstractCommand {
           ->setName('YOUR COMMAND NAME')
           ->setDescription('YOUR COMMAND DESCRIPTION');
   }
-  protected function fire()
+  protected function fire(): int
   {
     // Your logic here!
+
+    return 0;
   }
 }
 ```

--- a/docs/extend/database.md
+++ b/docs/extend/database.md
@@ -30,18 +30,15 @@ You may choose to not support all database systems, but you should specify which
 
 Flarum adds the following query builder methods to simplify writing queries specific to a database system:
 
+Each method takes two closures: the first runs when the connection matches that driver, the second (`$else`) runs otherwise. Both arguments are required.
+
 ```php
 // this is just an example, otherwise you would just use eloquent's whereYear method.
 $query
-  ->whenMySql(function ($query) {
-      $query->whereRaw('YEAR(created_at) = 2022');
-  })
-  ->whenPgSql(function ($query) {
-      $query->whereRaw('strftime("%Y", created_at) = 2022');
-  })
-  ->whenSqlite(function ($query) {
-      $query->whereRaw('EXTRACT(YEAR FROM created_at) = 2022');
-  });
+  ->whenMySql(
+      fn ($query) => $query->whereRaw('YEAR(created_at) = 2022'),
+      fn ($query) => $query->whereRaw('EXTRACT(YEAR FROM created_at) = 2022'),
+  );
 ```
 
 ## Common pitfalls

--- a/docs/extend/forms.md
+++ b/docs/extend/forms.md
@@ -17,7 +17,7 @@ You'll typically want to assign logic for reacting to input changes via Mithril'
 
 ```jsx
 import Component from 'flarum/common/Component';
-import Form from 'flarum/common/Form';
+import Form from 'flarum/common/components/Form';
 import FieldSet from 'flarum/common/components/FieldSet';
 import Button from 'flarum/common/components/Button';
 import Switch from 'flarum/common/components/Switch';
@@ -55,7 +55,7 @@ Don't forget to use [translations](i18n.md)!
 
 ## Streams, bidi, and withAttr
 
-Flarum provides [Mithril's Stream](https://mithril.js.org/stream.html) as `flarum/common/util/Stream`.
+Flarum provides [Mithril's Stream](https://mithril.js.org/stream.html) as `flarum/common/utils/Stream`.
 This is a very powerful reactive data structure, but is most commonly used in Flarum as a wrapper for form data.
 Its basic usage is:
 

--- a/docs/extend/frontend-pages.md
+++ b/docs/extend/frontend-pages.md
@@ -28,7 +28,7 @@ export default class CustomPage extends Page {
 
 ### Forum Page Structure
 
-Flarum's forum frontend uses a generic page structure, which is defined in `flarum/common/components/PageStructure`. This structure is used by all forum pages, and is recommended for use in extensions as well. You will have noticed that each forum page has a hero, sidebar, and content area among other things. These are all defined in `PageStructure` and can be used in your extension as well.
+Flarum's forum frontend uses a generic page structure, which is defined in `flarum/forum/components/PageStructure`. This structure is used by all forum pages, and is recommended for use in extensions as well. You will have noticed that each forum page has a hero, sidebar, and content area among other things. These are all defined in `PageStructure` and can be used in your extension as well.
 
 For example, a custom page component can use the `PageStructure` component as follows:
 
@@ -66,10 +66,10 @@ An example from the [Tags extension](https://github.com/flarum/tags/blob/master/
 
 ```js
 import { extend } from 'flarum/common/extend';
-import BasicsPage from 'flarum/common/components/BasicsPage';
+import BasicsPage from 'flarum/admin/components/BasicsPage';
 
 export default function() {
-  extend(BasicsPage.prototype, 'homePageItems', items => {
+  extend(BasicsPage, 'homePageItems', items => {
     items.add('tags', {
       path: '/tags',
       label: app.translator.trans('flarum-tags.admin.basics.tags_label')
@@ -143,10 +143,10 @@ app.current.get(KEY);
 
 For example, this is how the Discussion Page makes its [`PostStreamState`](https://api.docs.flarum.org/js/2.x/classes/flarum.forum_states_poststreamstate.poststreamstate) instance globally available.
 
-You can also check the type and data of a page using `PostStreamState`'s `matches` method. For instance, if we want to know if we are currently on a discussion page:
+You can also check the type and data of a page using `PageState`'s `matches` method. For instance, if we want to know if we are currently on a discussion page:
 
 ```jsx
-import IndexPage from 'flarum/forum/components/DiscussionPage';
+import IndexPage from 'flarum/forum/components/IndexPage';
 import DiscussionPage from 'flarum/forum/components/DiscussionPage';
 
 // To just check page type

--- a/docs/extend/frontend.md
+++ b/docs/extend/frontend.md
@@ -178,7 +178,7 @@ We'll go over tools available for extensions below.
 You should familiarize yourself with proper syntax for [importing js modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import), as most extensions larger than a few lines will split their js into multiple files.
 
 Pretty much every Flarum extension will need to import *something* from Flarum Core.
-Like most extensions, core's JS source code is split up into `admin`, `common`, and `forum` folders. You can import the file by prefixing its path in the Flarum core source code with `flarum`. So `admin/components/AdminLinkButton` is available as `flarum/admin/components/AdminLinkButton`, `common/Component` is available as `flarum/common/Component`, and `forum/states/PostStreamState` is available as `flarum/forum/states/PostStreamState`.
+Like most extensions, core's JS source code is split up into `admin`, `common`, and `forum` folders. You can import the file by prefixing its path in the Flarum core source code with `flarum`. So `admin/components/ExtensionLinkButton` is available as `flarum/admin/components/ExtensionLinkButton`, `common/Component` is available as `flarum/common/Component`, and `forum/states/PostStreamState` is available as `flarum/forum/states/PostStreamState`.
 
 In some cases, an extension may want to extend code from another flarum extension. You can use the same [import format](./extending-extensions#importing-from-extensions) valid for any third-party extension.
 
@@ -346,7 +346,7 @@ Now that we have a better understanding of the component system, let's go a bit 
 
 ### ItemList
 
-As noted above, most easily extensible parts of the UI allow you to extend methods called `items` or something similar (e.g. `controlItems`, `accountItems`, `toolbarItems`, etc. Exact names depend on the component you are extending) to add, remove, or replace elements. Under the surface, these methods return a `utils/ItemList` instance, which is essentially an ordered object. Detailed documentation of its methods is available in [our API documentation](https://api.docs.flarum.org/js/2.x/classes/flarum.common_utils_itemlist.itemlist). When the `toArray` method of ItemList is called, items are returned in ascending order of priority (0 if not provided), then by key alphabetically where priorities are equal.
+As noted above, most easily extensible parts of the UI allow you to extend methods called `items` or something similar (e.g. `controlItems`, `accountItems`, `toolbarItems`, etc. Exact names depend on the component you are extending) to add, remove, or replace elements. Under the surface, these methods return a `utils/ItemList` instance, which is essentially an ordered object. Detailed documentation of its methods is available in [our API documentation](https://api.docs.flarum.org/js/2.x/classes/flarum.common_utils_itemlist.itemlist). When the `toArray` method of ItemList is called, items are returned in descending order of priority (0 if not provided) — higher-priority items come first — then by key alphabetically where priorities are equal.
 
 ### `extend` and `override`
 
@@ -441,9 +441,9 @@ Flarum defines (and provides) quite a few util and helper functions, which you m
 - `flarum/common/utils/classList` provides the [clsx library](https://www.npmjs.com/package/clsx), which is great for dynamically assembling a list of CSS classes for your components
 - `flarum/common/utils/extractText` extracts text as a string from Mithril component vnode instances (or translation vnodes).
 - `flarum/common/utils/throttleDebounce` provides the [throttle-debounce](https://www.npmjs.com/package/throttle-debounce) library
-- `flarum/common/helpers/avatar` displays a user's avatar
+- `flarum/common/components/Avatar` displays a user's avatar
 - `flarum/common/helpers/highlight` highlights text in strings: great for search results!
-- `flarum/common/helpers/icon` displays an icon, usually used for FontAwesome.
+- `flarum/common/components/Icon` displays an icon, usually used for FontAwesome.
 - `flarum/common/helpers/username` shows a user's display name, or "deleted" text if the user has been deleted.
 
 And there's a bunch more! Some are covered elsewhere in the docs, but the best way to learn about them is through [the source code](https://github.com/flarum/framework/tree/main/framework/core/js) or [our javascript API documentation](https://api.docs.flarum.org/js/).

--- a/docs/extend/haptic-feedback.md
+++ b/docs/extend/haptic-feedback.md
@@ -180,7 +180,7 @@ import CommentPost from 'flarum/forum/components/CommentPost';
 
 app.initializers.add('my-extension', () => {
   // Example: haptic when user expands a collapsed post
-  extend(CommentPost.prototype, 'toggleCollapse', function () {
+  extend(CommentPost.prototype, 'toggleContent', function () {
     haptic('light');
   });
 });

--- a/docs/extend/i18n.md
+++ b/docs/extend/i18n.md
@@ -123,7 +123,7 @@ There's more to be said about referencing &mdash; for one thing, we've totally i
 
 ## Using the Translator
 
-Once you've added a translation to your locale file, with appropriate namespacing and identifier keys, you can use the `app.translator.trans()` method to reference that translation in your code. For instance, the `js/forum/src/index.js` file for the [Quick Start tutorial](start.md) might end up looking like this:
+Once you've added a translation to your locale file, with appropriate namespacing and identifier keys, you can use the `app.translator.trans()` method to reference that translation in your code. For instance, the `js/src/forum/index.ts` file for the [Quick Start tutorial](start.md) might end up looking like this:
 
 ```javascript
 app.initializers.add('acme-hello-world', function() {
@@ -140,7 +140,7 @@ You can include variables in translations. As an example, let's look at the code
 ```jsx harmony
 {LinkButton.component({
   icon: 'search',
-  children: app.translator.trans('all_discussions_button', {query}),
+  children: app.translator.trans('core.lib.search_source.discussions.all_button', {query}),
   href: app.route('index', {q: query})
 })}
 ```
@@ -148,7 +148,7 @@ You can include variables in translations. As an example, let's look at the code
 A matching placeholder in the translation lets the translator know where it should insert the variable:
 
 ```yaml
-all_discussions_button: 'Search all discussions for "{query}"'
+all_button: 'Search all discussions for "{query}"'
 ```
 
 Since curly brackets are used to denote the placeholder, the translation as a whole needs to be enclosed in [quotation marks](#quotation-marks). Normally, double quotes would be used; but since this particular translation is using double quotes to set off the search query, the single-quote rule takes precedence.
@@ -157,7 +157,7 @@ Since curly brackets are used to denote the placeholder, the translation as a wh
 
 Abstracting translations from HTML can pose a unique challenge: How do you deal with HTML elements that affect just part of the sentence? Fortunately, Flarum gives you a way to add tags to your translations.
 
-You begin by adding a key to the parameters argument for each element that you want the translator to handle. The following snippet — from the [Edit Group modal](https://github.com/flarum/framework/blob/main/framework/core/js/src/admin/components/EditGroupModal.js) of the admin interface — shows a translation key accompanied by a parameters object with one item.
+You begin by adding a key to the parameters argument for each element that you want the translator to handle. The following snippet — from the [Edit Group modal](https://github.com/flarum/framework/blob/main/framework/core/js/src/admin/components/EditGroupModal.tsx) of the admin interface — shows a translation key accompanied by a parameters object with one item.
 
 ```jsx harmony
 <div className="helpText">

--- a/docs/extend/interactive-components.md
+++ b/docs/extend/interactive-components.md
@@ -38,8 +38,10 @@ As opposed to alerts, most modals will use a custom class, inheriting `flarum/co
 import Modal from 'flarum/common/components/Modal';
 
 export default class CustomModal extends Modal {
-  // True by default, dictates whether the modal can be dismissed by clicking on the background or in the top right corner.
-  static isDismissible = true;
+  // All true by default. These control whether the modal can be dismissed via the close button, the Esc key, and clicking the backdrop, respectively.
+  static isDismissibleViaCloseButton = true;
+  static isDismissibleViaEscKey = true;
+  static isDismissibleViaBackdropClick = true;
 
   className() {
     // Custom CSS classes to apply to the modal
@@ -64,8 +66,10 @@ Modals with forms inherit `flarum/common/components/FormModal`. This class provi
 import FormModal from 'flarum/common/components/FormModal';
 
 export default class CustomFormModal extends FormModal {
-  // True by default, dictates whether the modal can be dismissed by clicking on the background or in the top right corner.
-  static isDismissible = true;
+  // All true by default. These control whether the modal can be dismissed via the close button, the Esc key, and clicking the backdrop, respectively.
+  static isDismissibleViaCloseButton = true;
+  static isDismissibleViaEscKey = true;
+  static isDismissibleViaBackdropClick = true;
 
   className() {
     // Custom CSS classes to apply to the modal

--- a/docs/extend/notifications.md
+++ b/docs/extend/notifications.md
@@ -12,7 +12,7 @@ To define a notification type, you will need to create a new class which impleme
 * `getSubject()` The model that the notification is about (eg. the `Post` that was liked).
 * `getData()` Any other data you might wish to include for access on the frontend (eg. the old discussion title when renamed).
 * `getType()` This is where you name your notification, this will be important for later steps.
-* `getSubjectModal()`: Specify the type of model the subject is (from `getSubject`).
+* `getSubjectModel()`: Specify the type of model the subject is (from `getSubject`).
 
 Lets take a look at an example from [Flarum Likes](https://github.com/flarum/likes/blob/master/src/Notification/PostLikedBlueprint.php):
 
@@ -107,10 +107,12 @@ Let's take a look at an example from [Flarum Mentions](https://github.com/flarum
 
 namespace Flarum\Mentions\Notification;
 
+use Flarum\Database\AbstractModel;
 use Flarum\Notification\AlertableInterface;
 use Flarum\Notification\Blueprint\BlueprintInterface;
 use Flarum\Notification\MailableInterface;
 use Flarum\Post\Post;
+use Flarum\User\User;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class PostMentionedBlueprint implements BlueprintInterface, AlertableInterface, MailableInterface
@@ -263,7 +265,7 @@ First, create a class that extends the notification component. Then, there are 4
 * `icon()`: The [Font Awesome](https://fontawesome.com/) icon that will appear next to the notification text (example: `fas fa-code-branch`).
 * `href()`: The link that should be opened when the notification is clicked (example: `app.route.post(this.attrs.notification.subject())`).
 * `content()`: What the notification itself should show. It should say the username and then the action. It will be followed by when the notification was sent (make sure to use translations).
-* `exerpt()`: (optional) A little excerpt that is shown below the notification (commonly an excerpt of a post).
+* `excerpt()`: A little excerpt that is shown below the notification (commonly an excerpt of a post).
 
 *Let take a look at our example shall we?*
 
@@ -355,7 +357,6 @@ From [Flarum Likes](https://github.com/flarum/likes/blob/master/src/Listener/Sen
 
 namespace Flarum\Likes\Listener;
 
-use Flarum\Event\ConfigureNotificationTypes;
 use Flarum\Likes\Event\PostWasLiked;
 use Flarum\Likes\Event\PostWasUnliked;
 use Flarum\Likes\Notification\PostLikedBlueprint;

--- a/docs/extend/routes.md
+++ b/docs/extend/routes.md
@@ -166,7 +166,7 @@ import FoobarPage from './components/FoobarPage';
 
 export default [
   new Extend.Routes()
-    .add('acme.foobar', '/foobar', <FoobarPage />),
+    .add('acme.foobar', '/foobar', FoobarPage),
 ];
 ```
 
@@ -190,7 +190,7 @@ Frontend routes also allow you to capture segments of the URI:
 
 ```jsx
   new Extend.Routes()
-    .add('acme.user', '/user/:id', <UsersPage />)
+    .add('acme.user', '/user/:id', UsersPage)
 ```
 
 Route parameters will be passed into the `attrs` of the route's component. They will also be available through [`m.route.param`](https://mithril.js.org/route.html#mrouteparam)

--- a/docs/extend/search.md
+++ b/docs/extend/search.md
@@ -63,7 +63,7 @@ We can use a *search mutator* for this:
 namespace YourPackage\Filter;
 
 use Flarum\Search\Database\DatabaseSearchState;
-use Flarum\Seach\SeachCriteria;
+use Flarum\Search\SearchCriteria;
 
 class OnlySameCountrySearchMutator
 {
@@ -144,7 +144,7 @@ return [
   
     (new Extend\SearchDriver(DatabaseSearchDriver::class))
         ->addSearcher(Acme::class, AcmeSearcher::class)
-        ->setFullText(AcmeSearcher::class, AcmeFulltextFilter::class),
+        ->setFulltext(AcmeSearcher::class, AcmeFulltextFilter::class),
     
   // Other extenders..
 ];
@@ -184,7 +184,7 @@ return [
     (new Extend\SearchDriver(AcmeSearchDriver::class))
         ->addSearcher(Acme::class, AcmeSearcher::class)
         // Optionally, you can set a fulltext filter for your searcher, a filter and/or a mutator.
-        ->setFullText(AcmeSearcher::class, AcmeFulltextFilter::class)
+        ->setFulltext(AcmeSearcher::class, AcmeFulltextFilter::class)
         ->addFilter(AcmeSearcher::class, AcmeFilter::class)
         ->addMutator(AcmeSearcher::class, AcmeMutator::class),
     

--- a/docs/extend/settings.md
+++ b/docs/extend/settings.md
@@ -89,7 +89,7 @@ return [
         // In this example, we'll append a string to it.
 
         return "My Cool Setting: $retrievedValue";
-      }, "default value!"),
+      }),
 ]
 ```
 

--- a/docs/extend/testing.md
+++ b/docs/extend/testing.md
@@ -442,7 +442,7 @@ For example:
 
 namespace CoolExtension\Tests\integration;
 
-use Flarum\Tests\integration\ConsoleTestCase;
+use Flarum\Testing\integration\ConsoleTestCase;
 use PHPUnit\Framework\Attributes\Test;
 
 class ConsoleTest extends ConsoleTestCase
@@ -598,7 +598,7 @@ Integration tests are used to test the components of your frontend code and the 
 Here's a simple example of an integration test for core's `Alert` component:
 
 ```ts
-import bootstrapForum from '@flarum/jest-config/src/boostrap/forum';
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 import Alert from '../../../../src/common/components/Alert';
 import m from 'mithril';
 import mq from 'mithril-query';
@@ -677,7 +677,7 @@ You cannot bootstrap both the forum and admin app in the same test file. If you 
 ###### Examples
 
 ```ts
-import bootstrapForum from '@flarum/jest-config/src/boostrap/forum';
+import bootstrapForum from '@flarum/jest-config/src/bootstrap/forum';
 
 describe('Forum tests', () => {
   beforeAll(() => bootstrapForum());
@@ -689,7 +689,7 @@ describe('Forum tests', () => {
 ```
 
 ```ts
-import bootstrapAdmin from '@flarum/jest-config/src/boostrap/admin';
+import bootstrapAdmin from '@flarum/jest-config/src/bootstrap/admin';
 
 describe('Admin tests', () => {
   beforeAll(() => bootstrapAdmin());

--- a/docs/extend/update-2_0-api.md
+++ b/docs/extend/update-2_0-api.md
@@ -279,7 +279,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
     } 
 
     // insert-start
-    public function creating(object $model, OriginalContext $context): ?object
+    public function creating(object $model, Context $context): ?object
     {
         $model->user_id = $context->getActor()->id;
         $model->ip_address = $context->request->getAttribute('ipAddress');
@@ -458,7 +458,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         ];  
     } 
 
-    public function creating(object $model, OriginalContext $context): ?object
+    public function creating(object $model, Context $context): ?object
     {
         $model->user_id = $context->getActor()->id;
         $model->ip_address = $context->request->getAttribute('ipAddress');
@@ -468,7 +468,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
     }
 
     // insert-start
-    public function updating(object $model, OriginalContext $context): ?object
+    public function updating(object $model, Context $context): ?object
     {
         $model->ip_address = $context->request->getAttribute('ipAddress');
         $model->updated_at = Carbon::now();
@@ -595,7 +595,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         ];  
     } 
 
-    public function creating(object $model, OriginalContext $context): ?object
+    public function creating(object $model, Context $context): ?object
     {
         $model->user_id = $context->getActor()->id;
         $model->ip_address = $context->request->getAttribute('ipAddress');
@@ -604,7 +604,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         return $model;
     }
 
-    public function updating(object $model, OriginalContext $context): ?object
+    public function updating(object $model, Context $context): ?object
     {
         $model->ip_address = $context->request->getAttribute('ipAddress');
         $model->updated_at = Carbon::now();
@@ -665,7 +665,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
     }
 
     // insert-start
-    public function scope(Builder $query, OriginalContext $context): void
+    public function scope(Builder $query, Context $context): void
     {
         $query->where('user_id', $context->getActor()->id);
     }
@@ -728,7 +728,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         ];  
     } 
 
-    public function creating(object $model, OriginalContext $context): ?object
+    public function creating(object $model, Context $context): ?object
     {
         $model->user_id = $context->getActor()->id;
         $model->ip_address = $context->request->getAttribute('ipAddress');
@@ -737,7 +737,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         return $model;
     }
 
-    public function updating(object $model, OriginalContext $context): ?object
+    public function updating(object $model, Context $context): ?object
     {
         $model->ip_address = $context->request->getAttribute('ipAddress');
         $model->updated_at = Carbon::now();
@@ -808,7 +808,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         return Draft::class;  
     }
 
-    public function scope(Builder $query, OriginalContext $context): void
+    public function scope(Builder $query, Context $context): void
     {
         $query->where('user_id', $context->getActor()->id);
     }
@@ -877,7 +877,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         ];  
     } 
 
-    public function creating(object $model, OriginalContext $context): ?object
+    public function creating(object $model, Context $context): ?object
     {
         $model->user_id = $context->getActor()->id;
         $model->ip_address = $context->request->getAttribute('ipAddress');
@@ -886,7 +886,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
         return $model;
     }
 
-    public function updating(object $model, OriginalContext $context): ?object
+    public function updating(object $model, Context $context): ?object
     {
         $model->ip_address = $context->request->getAttribute('ipAddress');
         $model->updated_at = Carbon::now();
@@ -917,7 +917,7 @@ class DraftResource extends Resource\AbstractDatabaseResource
 {
     ...
 
-    public function scope(Builder $query, OriginalContext $context): void
+    public function scope(Builder $query, Context $context): void
     {
         $query->whereVisibleTo($context->getActor());
     }
@@ -1658,7 +1658,7 @@ class FlagResource extends AbstractDatabaseResource
     ...
 
     // insert-start
-    public function scope(Builder $query, OriginalContext $context): void
+    public function scope(Builder $query, Context $context): void
     {
         $query->whereVisibleTo($actor);
         

--- a/docs/extend/update-2_0.md
+++ b/docs/extend/update-2_0.md
@@ -101,7 +101,7 @@ Familiarize yourself with the new [Code Splitting](./code-splitting) feature to 
 * The forum search UI has been refactored to use a new `SearchModal` component.
 * The `flarum/forum/components/Search` component is no longer the global search component, it can still be used for custom search purposes.
 * Custom global search sources should be registered in `flarum/forum/components/GlobalSearch` `sourceItems` method.
-* Custom global search sources should now implement the `GlobalSearchSource` interface instead of `SearchSource`, see https://github.com/flarum/framework/blob/2.x/framework/core/js/src/common/components/AbstractSearch.tsx#L26-L69.
+* Custom global search sources should now implement the `GlobalSearchSource` interface instead of `SearchSource`, see https://github.com/flarum/framework/blob/2.x/framework/core/js/src/common/components/AbstractGlobalSearch.tsx#L26-L69.
 * The `flarum/forum/states/SearchState` class has been moved to `flarum/common/states/SearchState`.
 
 ### Admin Search
@@ -317,7 +317,7 @@ Flarum 2.0 completely refactors the JSON:API implementation. The way resource CR
 * The `AbstractSerializer` has been removed.
 * The `ApiController` and `ApiSerializer` extenders have been removed.
 * The `Saving` are dispatched after the validation process instead of before.
-* The various validators have been removed. This includes the `DiscussionValidator`, `PostValidator`, `TagValidator`, `SuspendValidator`, `GroupValidator`, `UserValidator`.
+* Several validators have been removed. This includes the `DiscussionValidator`, `PostValidator`, `TagValidator`, `SuspendValidator`, and `GroupValidator`. (`UserValidator` is still present.)
 * Many command handlers have been removed. Use the `JsonApi` class if you wish to execute logic from an existing endpoint internally instead.
 * The `flarum.forum.discussions.sortmap` singleton has been removed. Instead, you can define an `ascendingAlias` and `descendingAlias` [on your added `SortColumn` sorts](./api#adding-sort-columns).
 * The `show` discussion endpoint no longer includes the `posts` relationship, so any `posts.*` relation includes or eager loads added to that endpoint must be removed. You can move those to the `list` posts endpoint if you are not already doing the same on that endpoint.

--- a/docs/extend/views.md
+++ b/docs/extend/views.md
@@ -47,7 +47,7 @@ Note that all Blade templates rendered this way automatically have access to the
 
 - `$url`: a [URL generator](routes#generating-urls) instance.
 - `$translator`: a [Translator](i18n#server-side-translation) instance.
-- `$settings`: a [SettingsInterface](settings) instance.
+- `$settings`: a [SettingsRepositoryInterface](settings) instance.
 - `$slugManager`: a [SlugManager](slugging) instance.
 
 Additionally, templates used by [content logic](routes#content) have access to `$forum`, which represents the [Forum API Document's attributes](https://github.com/flarum/framework/blob/2.x/framework/core/src/Api/Resource/ForumResource.php).

--- a/docs/install.md
+++ b/docs/install.md
@@ -25,6 +25,18 @@ Before you install Flarum, it's important to check that your server meets the re
   * PostgreSQL 10.0+
 * **SSH (command-line) access** to run potentially necessary software maintenance commands, and Composer if you intend on using the command-line to install and manage Flarum extensions.
 
+:::tip Recommended database versions
+
+The versions above are the minimums Flarum supports, but older releases such as **MySQL 5.7** and **MariaDB 10.x** are approaching (or past) their upstream end-of-life and are **not recommended** for new installs. For the best performance and longest support window, we recommend running a current LTS-grade release:
+
+* **MySQL 8.4 LTS**
+* **MariaDB 11.8 LTS**
+* **PostgreSQL 15, 16, or 17**
+
+These are the versions Flarum is actively developed and tested against. Note that Flarum treats **MySQL and MariaDB as distinct database drivers** — make sure your `config.php` `driver` matches the server you're actually connecting to.
+
+:::
+
 ## Installing
 
 ### Installing by unpacking an archive

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -85,7 +85,7 @@ At the moment, 3 token types exist, although only 2 types can be created via the
 - `session_remember` tokens expire after 5 years of inactivity. They can be obtained by specifying `remember=1` in the request attributes.
 - `developer` tokens never expire. They can only be created manually in the database at the moment.
 
-**All access tokens are deleted when the user logs out** (this includes `developer` tokens, although it is planned to change it).
+**Logging out deletes only the access token used by that session.** A global logout (`POST /logout` with `?global=1`), and changing the user's password, delete *all* of the user's access tokens — including `developer` tokens.
 
 #### Usage
 

--- a/docs/update.md
+++ b/docs/update.md
@@ -32,6 +32,12 @@ Flarum 2.0 requires **PHP 8.3 or higher**. Check your current version with `php 
 
 Also confirm you're on Composer 2: `composer --version`.
 
+:::tip Check your database version too
+
+Flarum 2.0 still supports older databases, but releases such as **MySQL 5.7** and **MariaDB 10.x** are at or near upstream end-of-life and are **not recommended**. If you're planning maintenance anyway, this is a good moment to move to a current LTS-grade release: **MySQL 8.4 LTS**, **MariaDB 11.8 LTS**, or **PostgreSQL 15/16/17** — the versions Flarum is actively tested against.
+
+:::
+
 **3. Check for incompatible or superseded extensions.**
 Some extensions are no longer compatible with v2, and some have been superseded:
 


### PR DESCRIPTION
Cross-referenced the Flarum 2.x `extend/` documentation against the framework source and fixed confirmed inaccuracies — examples that would error, reference removed/renamed 1.x APIs, or point at the wrong namespace/path. Each fix was verified against current `2.x` source.

## Corrections (by file)

- **api.md** — `removeField`/`removeEndpoint`/`removeSort` → plural array forms; `avgReation` → `avgRelation`; stray comma in the endpoint chain; `Rsource` namespace typo
- **admin.md** — `generalIndexItems` needs a type arg; `Admin.settings`/`.permissions` → `setting`/`permission`; corrected the "Available Categories" table to the four categories actually registered; rewrote the abandoned-extensions paragraph (the scheduled `extensions:sync-abandoned` checker already exists, it isn't "planned")
- **frontend.md** — `avatar`/`icon` are components, not helpers; `ItemList.toArray` is **descending** priority; `AdminLinkButton` doesn't exist → `ExtensionLinkButton`
- **frontend-pages.md** — `PageStructure`/`BasicsPage` namespaces; `homePageItems` is static (don't extend `.prototype`); `matches()` is on `PageState`; fixed `IndexPage` import
- **console.md** — `fire(): int` with a return; dropped unused PSR-7/15 imports
- **database.md** — `whenMySql`/`whenPgSql`/`whenSqlite` require both a callback **and** an `$else`
- **interactive-components.md** — `isDismissible` split into `isDismissibleViaCloseButton`/`ViaEscKey`/`ViaBackdropClick`
- **notifications.md** — `getSubjectModel`; `excerpt`; added missing `AbstractModel`/`User` imports; dropped stale `ConfigureNotificationTypes` import
- **routes.md** — pass the component **class**, not a JSX instance
- **update-2_0-api.md** — `OriginalContext` → `Context`
- **update-2_0.md** — `UserValidator` is **not** removed; `AbstractGlobalSearch` path
- **rest-api.md** — only the **current** token is deleted on logout; global logout and password change delete all
- **api-throttling.md** — actor via `RequestUtil::getActor($request)`, not `getAttribute('actor')`
- **authorization / avatars / forms / search / settings / testing / views / i18n** — namespace, method-name, path, and translation-key corrections

## Additions

- **admin.md** — documented the recommended declarative `extend.ts` pattern for registering settings, permissions, and an admin **page**, with the required `export { default as extend } from './extend';` line in `index.ts` and a note on what belongs in the initializer vs the extender.
- **install.md / update.md** — added recommended database-version guidance: **MySQL 8.4 LTS**, **MariaDB 11.8 LTS**, **PostgreSQL 15/16/17** are what Flarum is tested against; **MySQL 5.7** and **MariaDB 10.x** are still supported but not recommended.

## Not included

A separate set of `extend/` pages (`mail`, `middleware`, etc.) are byte-identical to the 1.x snapshot and need full 2.x rewrites rather than line edits — those are deferred to follow-up PRs. `api-throttling`'s `getActor` fix was a clean one-liner so it's included here.