### PR TITLE
Rewrite mail and middleware extend pages for 2.x

### DIFF
--- a/docs/extend/mail.md
+++ b/docs/extend/mail.md
@@ -1,35 +1,51 @@
 # Mail Drivers
 
-In addition to the [default drivers in core](../mail.md), Flarum allows new mail drivers to be added through extenders. To create your own mail driver, you'll need to create a class implementing `\Flarum\Mail\DriverInterface`. Flarum actually takes care of the frontend for providing email settings: just declare which settings you need, and any default values, in `availableSettings`.
+In addition to the [default drivers in core](../mail.md), Flarum allows new mail drivers to be added through extenders. To create your own mail driver, you'll need to create a class implementing `\Flarum\Mail\DriverInterface`. Flarum takes care of the frontend for providing email settings: just declare which settings you need, and any default values, in `availableSettings()`.
 
-For example:
+:::info Symfony Mailer
+
+Flarum 2.0 uses [Symfony Mailer](https://symfony.com/doc/current/mailer.html) under the hood (Flarum 1.x used Swiftmailer). A driver's `buildTransport()` therefore returns a `Symfony\Component\Mailer\Transport\TransportInterface`, which you typically obtain from one of Symfony's transport factories.
+
+:::
+
+The `DriverInterface` declares the following methods:
+
+- **`availableSettings(): array`** — the settings this driver needs. Each key is a setting name; the value is either an empty string `''` for a free-text field, or an array of `value => label` pairs for a dropdown. Flarum renders these automatically on the admin mail page.
+- **`validate(SettingsRepositoryInterface $settings, Factory $validator): MessageBag`** — validate the configured settings and **return** the resulting `MessageBag`. Return an empty `MessageBag` when everything is valid; if validation fails, Flarum falls back to the no-op `NullDriver`.
+- **`canSend(): bool`** — whether this driver can actually send mail with its current configuration.
+- **`buildTransport(SettingsRepositoryInterface $settings): TransportInterface`** — build and return the Symfony Mailer transport.
+
+Here is core's own Mailgun driver as a complete example:
 
 ```php
 use Flarum\Mail\DriverInterface;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Illuminate\Contracts\Validation\Factory;
-use Illuminate\Mail\Transport\MailgunTransport;
 use Illuminate\Support\MessageBag;
-use Swift_Transport;
+use Symfony\Component\Mailer\Bridge\Mailgun\Transport\MailgunTransportFactory;
+use Symfony\Component\Mailer\Transport\Dsn;
+use Symfony\Component\Mailer\Transport\TransportInterface;
 
 class MailgunDriver implements DriverInterface
 {
     public function availableSettings(): array
     {
         return [
-            'setting_one' => '',
-            'setting_two' => 'defaultValue',
-            'dropdown_setting' => [
-                'option_one_val' => 'Option One Display',
-                'option_two_val' => 'Option Two Display',
+            'mail_mailgun_secret' => '', // the secret key
+            'mail_mailgun_domain' => '', // the sending domain
+            'mail_mailgun_region' => [ // region's endpoint (dropdown)
+                'api.mailgun.net' => 'US',
+                'api.eu.mailgun.net' => 'EU',
             ],
         ];
     }
 
     public function validate(SettingsRepositoryInterface $settings, Factory $validator): MessageBag
     {
-        $validator->make($settings->all(), [
-            'setting_one' => 'required',
-            'setting_two' => 'nullable|integer',
+        return $validator->make($settings->all(), [
+            'mail_mailgun_secret' => ['required'],
+            'mail_mailgun_domain' => ['required'],
+            'mail_mailgun_region' => 'required|in:api.mailgun.net,api.eu.mailgun.net',
         ])->errors();
     }
 
@@ -38,22 +54,40 @@ class MailgunDriver implements DriverInterface
         return true;
     }
 
-    public function buildTransport(SettingsRepositoryInterface $settings): Swift_Transport
+    public function buildTransport(SettingsRepositoryInterface $settings): TransportInterface
     {
-        // Return a mail transport that implements Swift Transport
+        $factory = new MailgunTransportFactory();
+
+        return $factory->create(new Dsn(
+            'mailgun+api',
+            $settings->get('mail_mailgun_region'),
+            $settings->get('mail_mailgun_secret'),
+            $settings->get('mail_mailgun_domain')
+        ));
     }
 }
 ```
 
-To register mail drivers, use the `Flarum\Extend\Mail` extender in your extension's `extend.php` file:
+:::tip
+
+Symfony ships transport factories for many providers (Amazon SES, Mailgun, Postmark, Sendgrid, and more) as separate `symfony/*-mailer` bridge packages. Require the bridge you need in your extension's `composer.json` and use its `TransportFactory` inside `buildTransport()`, exactly as the example does for Mailgun. For a plain SMTP server, build a `Symfony\Component\Mailer\Transport\Dsn` with the `smtp`/`smtps` scheme — see core's `Flarum\Mail\SmtpDriver` for a reference implementation.
+
+:::
+
+## Registering the driver
+
+To register a mail driver, use the `Flarum\Extend\Mail` extender in your extension's `extend.php` file. The `driver()` method takes **two** arguments: a string identifier (used as the value of the `mail_driver` setting) and the driver's class-string.
 
 ```php
 use Flarum\Extend;
 use YourNamespace\Mail\CustomDriver;
 
 return [
-  // Other extenders
-  (new Extend\Mail())->driver(CustomDriver::class)
-  // Other extenders
+    // Other extenders
+    (new Extend\Mail())
+        ->driver('custom', CustomDriver::class),
+    // Other extenders
 ];
 ```
+
+The identifier (`'custom'` above) is what an administrator selects on the admin mail page to activate your driver.

--- a/docs/extend/middleware.md
+++ b/docs/extend/middleware.md
@@ -40,7 +40,7 @@ return [
     // API frontend
     (new Extend\Middleware('api'))->add(YourMiddleware::class),
 
-    (new Extend\Middleware('frontend'))
+    (new Extend\Middleware('forum'))
         // remove a middleware (e.g. remove CSRF token check 😱)
         ->remove(CheckCsrfToken::class)
         // insert before another middleware (e.g. before a CSRF token check)
@@ -53,6 +53,12 @@ return [
 ```
 
 Tada! Middleware registered. Remember that order matters.
+
+:::info Available stacks
+
+The `Middleware` extender accepts one of three stacks: `'forum'`, `'admin'`, or `'api'`. There is no single combined `'frontend'` stack — if you need your middleware on both the forum and admin frontends, register it against each.
+
+:::
 
 Now that we've got the basics down, let's run through a few more things:
 
@@ -93,34 +99,47 @@ Of course, you can use any condition, not just the current route. Simple, right?
 
 ## Returning Your Own Response
 
-Let's refer back to the example and say you're checking a user against an external database during registration. One user registers and they are found in this database. Uh-oh! Let's keep them from registering:
+Let's refer back to the example and say you're checking a user against an external database during registration. One user registers and they are found in this database. Uh-oh! Let's keep them from registering.
+
+The simplest way to reject input with a field-scoped error is to throw a `Flarum\Foundation\ValidationException`. Flarum's error handler turns it into a properly-formatted JSON:API `422` error response for you:
 
 ```php
-use Flarum\Api\JsonApiResponse;
-use Tobscure\JsonApi\Document;
-use Tobscure\JsonApi\Exception\Handler\ResponseBag;
+use Flarum\Foundation\ValidationException;
 
 public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
 {
     if ($userFoundInDatabase) {
-        $error = new ResponseBag('422', [
-            [
-                'status' => '422',
-                'code' => 'validation_error',
-                'source' => [
-                    'pointer' => '/data/attributes/email',
-                ],
-                'detail' => 'Yikes! Your email can\'t be used.',
-            ],
+        // Keys are attribute names; values are the error messages.
+        throw new ValidationException([
+            'email' => 'Yikes! Your email can\'t be used.',
         ]);
-        $document = new Document();
-        $document->setErrors($error->getErrors());
-      
-        return new JsonApiResponse($document, $error->getStatus());
     }
 
     return $handler->handle($request);
 }
+```
+
+:::info JSON:API in 2.0
+
+Flarum 2.0 replaced the Tobscure JSON:API library with [`flarum/json-api-server`](https://github.com/flarum/json-api-server). The old `Tobscure\JsonApi\Document` / `ResponseBag` classes no longer exist. Throwing an exception (as above) is the recommended way to return errors from middleware.
+
+:::
+
+If you need full control over the body, `Flarum\Api\JsonApiResponse` now accepts a plain document array (rather than a Tobscure `Document`) and sets the `application/vnd.api+json` content type for you:
+
+```php
+use Flarum\Api\JsonApiResponse;
+
+return new JsonApiResponse([
+    'errors' => [
+        [
+            'status' => '422',
+            'code' => 'validation_error',
+            'source' => ['pointer' => '/data/attributes/email'],
+            'detail' => 'Yikes! Your email can\'t be used.',
+        ],
+    ],
+], 422);
 ```
 
 Phew! Crisis avoided.


### PR DESCRIPTION
Both `extend/mail.md` and `extend/middleware.md` were carried over verbatim from the 1.x docs (byte-identical to the 1.x snapshot) and document APIs that no longer exist in Flarum 2.x. This rewrites the affected parts against current `2.x` source.

## mail.md

Flarum 2.0 uses **Symfony Mailer** (1.x used Swiftmailer), so the whole driver example was wrong:

- `buildTransport()` returns `Symfony\Component\Mailer\Transport\TransportInterface`, not `Swift_Transport`
- `validate()` must **return** its `MessageBag`
- the example is now modelled on core's real `MailgunDriver` (Symfony transport factory + `Dsn`), with a note pointing to the `symfony/*-mailer` bridge packages and core's `SmtpDriver`
- the `Extend\Mail::driver()` extender takes **two** args — `driver('identifier', CustomDriver::class)` — not just the class

## middleware.md

The PSR-15 middleware mechanics were fine; two things were broken:

- the `Middleware` extender has no `'frontend'` stack — only `forum`, `admin`, and `api`. Added a note.
- the "Returning Your Own Response" example used the **removed** Tobscure `Document`/`ResponseBag` classes. Replaced with the 2.x approach: throw `Flarum\Foundation\ValidationException` (the recommended path), or build a `JsonApiResponse` from a plain document array (its 2.x constructor takes `array`, not a Tobscure `Document`).

All code verified against `framework/core` 2.x source (`DriverInterface`, `MailgunDriver`, `SmtpDriver`, `Extend\Mail`, `JsonApiResponse`, `ValidationException`, `Extend\Middleware`).

## Context

These are the first two of the remaining "Bucket A" pages that were never migrated from 1.x. Other such pages (`distribution`, `formatting`, `language-packs`, `permissions`, `theme`, `github-actions`) still need a 2.x verification pass, and the empty `post-types`/`slugging` stubs need authoring — separate follow-ups.