### PR TITLE
Document routing jobs to named queues via the Queue extender

### DIFF
--- a/docs/extend/update-2_0.md
+++ b/docs/extend/update-2_0.md
@@ -436,24 +436,21 @@ Checkout this example from the mentions extension:
 
 ### Queue
 
-Jobs can be routed onto a named queue with the new `Queue` extender, rather than by setting a property on the job class:
+In 1.x you routed a job onto a named queue by setting the `AbstractJob::$sendOnQueue` static property on the job class. That property has been removed; route jobs with the new `Queue` extender instead:
 
 ```php
 use Flarum\Extend;
 
 return [
+    // 1.x: SendExportJob::$sendOnQueue = 'exports';
     (new Extend\Queue())
         ->route(\Your\Extension\Jobs\SendExportJob::class, 'exports'),
 ];
 ```
 
-Routing a base or abstract class covers all of its subclasses (the most specific route wins), so a family of jobs can be sent to one queue by routing their shared parent. The queue is applied when the job is pushed, so it works for `dispatch()`, the low-level `push($job)`, and jobs dispatched by other extensions alike. See the [queue documentation](../queue.md#named-queues) for details.
+Routing a base or abstract class covers all of its subclasses (the most specific route wins), so if you set `$sendOnQueue` on a shared base class, route that same base class. The queue is now applied when the job is pushed, so it works for `dispatch()`, the low-level `push($job)`, and jobs dispatched by other extensions alike. See the [queue documentation](../queue.md#named-queues) for details.
 
-:::warning
-
-If you routed jobs by setting the `AbstractJob::$onQueue` static property (available on early 2.x development builds), use `Extend\Queue->route()` instead — the static has been removed, as it was shared across sibling job classes and silently mis-routed them.
-
-:::
+> The static was briefly renamed `$onQueue` on early 2.x development builds; either way, replace it with `Extend\Queue->route()`.
 
 ### OAuth / Forum Auth
 

--- a/docs/extend/update-2_0.md
+++ b/docs/extend/update-2_0.md
@@ -434,6 +434,27 @@ Checkout this example from the mentions extension:
 
 :::
 
+### Queue
+
+Jobs can be routed onto a named queue with the new `Queue` extender, rather than by setting a property on the job class:
+
+```php
+use Flarum\Extend;
+
+return [
+    (new Extend\Queue())
+        ->route(\Your\Extension\Jobs\SendExportJob::class, 'exports'),
+];
+```
+
+Routing a base or abstract class covers all of its subclasses (the most specific route wins), so a family of jobs can be sent to one queue by routing their shared parent. The queue is applied when the job is pushed, so it works for `dispatch()`, the low-level `push($job)`, and jobs dispatched by other extensions alike. See the [queue documentation](../queue.md#named-queues) for details.
+
+:::warning
+
+If you routed jobs by setting the `AbstractJob::$onQueue` static property (available on early 2.x development builds), use `Extend\Queue->route()` instead — the static has been removed, as it was shared across sibling job classes and silently mis-routed them.
+
+:::
+
 ### OAuth / Forum Auth
 
 ##### <span class="breaking">Breaking</span>

--- a/docs/extend/update-2_x.md
+++ b/docs/extend/update-2_x.md
@@ -6,5 +6,24 @@ If you need help applying these changes or using new features, please start a di
 
 :::
 
+## 2.0 Changes
+
+### Job queue routing
+
+Route a job class onto a named queue with the `Queue` extender:
+
+```php
+use Flarum\Extend;
+
+return [
+    (new Extend\Queue())
+        ->route(\Your\Extension\Jobs\SendExportJob::class, 'exports'),
+];
+```
+
+Routing a base or abstract class covers all of its subclasses (the most specific route wins), so a family of jobs can be sent to one queue by routing their shared parent. The queue is applied when the job is pushed, so it works for `dispatch()`, the low-level `push($job)`, and jobs dispatched by other extensions alike. See the [queue documentation](../queue.md#named-queues) for details.
+
+If you previously routed jobs by setting the `AbstractJob::$onQueue` static property, use `Extend\Queue->route()` instead — the static has been removed (it was shared across sibling job classes, so routing one silently overrode the others).
+
 ## 2.1 Changes
 

--- a/docs/extend/update-2_x.md
+++ b/docs/extend/update-2_x.md
@@ -6,24 +6,5 @@ If you need help applying these changes or using new features, please start a di
 
 :::
 
-## 2.0 Changes
-
-### Job queue routing
-
-Route a job class onto a named queue with the `Queue` extender:
-
-```php
-use Flarum\Extend;
-
-return [
-    (new Extend\Queue())
-        ->route(\Your\Extension\Jobs\SendExportJob::class, 'exports'),
-];
-```
-
-Routing a base or abstract class covers all of its subclasses (the most specific route wins), so a family of jobs can be sent to one queue by routing their shared parent. The queue is applied when the job is pushed, so it works for `dispatch()`, the low-level `push($job)`, and jobs dispatched by other extensions alike. See the [queue documentation](../queue.md#named-queues) for details.
-
-If you previously routed jobs by setting the `AbstractJob::$onQueue` static property, use `Extend\Queue->route()` instead — the static has been removed (it was shared across sibling job classes, so routing one silently overrode the others).
-
 ## 2.1 Changes
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -123,7 +123,16 @@ return [
 ];
 ```
 
-Every instance of that job class is then dispatched onto the `exports` queue, without changing the code that dispatches it. You can route as many job classes as you like — each keeps its own queue.
+Every instance of that job class is then dispatched onto the `exports` queue, without changing the code that dispatches it. You can route as many job classes as you like.
+
+Routing a base or abstract class covers all of its subclasses, so a family of related jobs can be sent to one queue by routing their shared parent:
+
+```php
+(new Extend\Queue())
+    ->route(\Your\Extension\Jobs\AbstractExportJob::class, 'exports'),
+```
+
+If a job matches more than one route through its class hierarchy, the most specific one wins — a route on the job's own class overrides one on a parent. An explicit queue passed when the job is dispatched always takes precedence over any route.
 
 You then run a worker across the queues you care about, in priority order — each queue is fully drained before the next:
 

--- a/docs/queue.md
+++ b/docs/queue.md
@@ -112,14 +112,18 @@ Pausing and resuming are recorded in the [audit log](extensions/audit.md) (as `q
 
 Jobs are not all equal — a time-sensitive notification should not sit behind a slow bulk export. Flarum (and the queue drivers) support **multiple named queues** so you can separate and prioritise work.
 
-A job declares its target queue with the core `AbstractJob::$onQueue` property:
+Route a job class onto a named queue with the `Queue` extender in your `extend.php`:
 
 ```php
-class SendExportJob extends \Flarum\Queue\AbstractJob
-{
-    public static ?string $onQueue = 'exports';
-}
+use Flarum\Extend;
+
+return [
+    (new Extend\Queue())
+        ->route(\Your\Extension\Jobs\SendExportJob::class, 'exports'),
+];
 ```
+
+Every instance of that job class is then dispatched onto the `exports` queue, without changing the code that dispatches it. You can route as many job classes as you like — each keeps its own queue.
 
 You then run a worker across the queues you care about, in priority order — each queue is fully drained before the next:
 


### PR DESCRIPTION
Follows flarum/framework#4853, which removes the `AbstractJob::$onQueue` static (a shared-static that silently collided when routing multiple job classes) in favour of a class-keyed registry.

Updates the **Named queues** section of the queue guide to route a job class with the new `Extend\Queue->route(JobClass::class, 'queue')` extender instead of setting `public static $onQueue`.

Merge after #4853.