### PR TITLE
docs(1.x): document error_reporting config for modern PHP

### DIFF
--- a/versioned_docs/version-1.x/extend/update-1_x.md
+++ b/versioned_docs/version-1.x/extend/update-1_x.md
@@ -15,7 +15,7 @@ If you need help applying these changes or using new features, please start a di
 
 ### Backend
 
-- Support for php 8.2, deprecations are still thrown by some packages, the testing workflow has been updated to ignore deprecations on 8.2
+- Support for php 8.2 (later extended through 8.5); deprecations are still thrown by some packages, so the testing workflow ignores deprecations on these versions. See [PHP Configuration](../install.md#php-configuration) for the recommended `error_reporting` setting.
 - The `/api` endpoint now contains the actor as an included relationship.
 - The `Model::dateAttribute($attribute)` extender is deprecated, use `Model::cast($attribute, 'datetime')` instead.
 

--- a/versioned_docs/version-1.x/install.md
+++ b/versioned_docs/version-1.x/install.md
@@ -15,6 +15,24 @@ Before you install Flarum, it's important to check that your server meets the re
 * **MySQL 5.6+/8.0.23+** or **MariaDB 10.0.5+**
 * **SSH (command-line) access** to run potentially necessary software maintenance commands, and Composer if you intend on using the command-line to install and manage Flarum extensions.
 
+## PHP Configuration
+
+Flarum 1.x runs on PHP up to and including 8.5, but it is built on an older framework stack. On modern PHP, some of its dependencies emit deprecation notices. This is expected and does not affect how Flarum works.
+
+Every PHP version that currently receives [official support](https://www.php.net/supported-versions.php) — 8.2, 8.3, 8.4 and 8.5 — is affected. In other words, if you are running Flarum 1.x on a PHP version that is still maintained (as you should be), you will encounter these notices, so the configuration below should be treated as a standard part of setting up Flarum 1.x.
+
+Configure PHP to exclude deprecation warnings so they don't fill your logs or leak into responses:
+
+```ini
+error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
+```
+
+On a typical production server `display_errors` is already off, so the notices are not shown to visitors — but they can still be written to your error log on every request, which the setting above prevents.
+
+:::tip Want a deprecation-free stack?
+These notices come from the older framework that Flarum 1.x is built on. Flarum 2.x runs on a current framework version and does not produce them. If you are starting fresh or able to upgrade, consider [Flarum 2.x](https://docs.flarum.org/2.x).
+:::
+
 ## Installing
 
 ### Installing by unpacking an archive

--- a/versioned_docs/version-1.x/install.md
+++ b/versioned_docs/version-1.x/install.md
@@ -29,6 +29,8 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
 
 On a typical production server `display_errors` is already off, so the notices are not shown to visitors — but they can still be written to your error log on every request, which the setting above prevents.
 
+In practice we see the best results running Flarum 1.x on **PHP 8.3**, which at the time of writing still receives [security support](https://www.php.net/supported-versions.php). If you have the choice, it is a good balance of stability and remaining support life for a 1.x install.
+
 :::warning Consider upgrading to Flarum 2.x
 
 These notices come from the older framework that Flarum 1.x is built on. That framework has itself reached end of life, so keeping 1.x running cleanly and securely on modern PHP takes progressively more effort over time.

--- a/versioned_docs/version-1.x/install.md
+++ b/versioned_docs/version-1.x/install.md
@@ -29,8 +29,14 @@ error_reporting = E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED
 
 On a typical production server `display_errors` is already off, so the notices are not shown to visitors — but they can still be written to your error log on every request, which the setting above prevents.
 
-:::tip Want a deprecation-free stack?
-These notices come from the older framework that Flarum 1.x is built on. Flarum 2.x runs on a current framework version and does not produce them. If you are starting fresh or able to upgrade, consider [Flarum 2.x](https://docs.flarum.org/2.x).
+:::warning Consider upgrading to Flarum 2.x
+
+These notices come from the older framework that Flarum 1.x is built on. That framework has itself reached end of life, so keeping 1.x running cleanly and securely on modern PHP takes progressively more effort over time.
+
+Flarum 1.x is officially on life support while we finalize the 2.0 release. Going forward, the 1.x line will receive critical and security fixes only — no new features — and that support will wind down over time. We encourage all Flarum 1.x installations to plan an upgrade to Flarum 2.x, which is built on a current, supported framework and does not produce these deprecations.
+
+Flarum 2.0 is in its release-candidate phase — the API is stable and many forums already run it in production — and a stable release is not far off. See the [Flarum 2.x documentation](https://docs.flarum.org/2.x) to get started.
+
 :::
 
 ## Installing


### PR DESCRIPTION
Running 1.x on any currently-supported PHP version throws deprecation notices from the old framework stack, and right now the docs don't really tell people what to do about it — the only mention is a stale line in the 1.x update guide that still says "PHP 8.2".

So this adds a **PHP Configuration** section to the 1.x install guide covering the `error_reporting` setting we all end up applying anyway, and notes that 8.3 is the sweet spot for a 1.x install these days. While I was in there I also used it to be honest about where 1.x stands — it's on life support while we get 2.0 over the line, security/critical fixes only from here, and everyone should be planning the move to 2.x.

Also refreshed that old 8.2 line in the update guide and pointed it at the new section.

Only touches the `version-1.x` docs.